### PR TITLE
Simplify types related to layout

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -142,8 +142,8 @@ export class FluidLayoutBuilder<TContent> implements IFluidLayoutBuilder<TConten
     build(): IFluidLayout<TContent>;
     // (undocumented)
     facade(): IFluidLayoutFacade<TContent>;
-    static for<TContent>(layout: IFluidLayout<TContent>): IFluidLayoutBuilderImpl<TContent>;
-    static forNewLayout<TContent>(): IFluidLayoutBuilderImpl<TContent>;
+    static for<TContent>(layout: IFluidLayout<TContent>): IFluidLayoutBuilder<TContent>;
+    static forNewLayout<TContent>(): IFluidLayoutBuilder<TContent>;
     // (undocumented)
     protected getRowBuilder: (rowIndex: number) => IFluidLayoutRowBuilder<TContent>;
     // (undocumented)
@@ -181,7 +181,7 @@ export class FluidLayoutColumnBuilder<TContent> implements IFluidLayoutColumnBui
     content(valueOrUpdateCallback: ValueOrUpdateCallback<TContent | undefined>): this;
     // (undocumented)
     facade(): IFluidLayoutColumnFacade<TContent>;
-    static for<TContent>(rowBuilder: IFluidLayoutRowBuilderImpl<TContent>, columnIndex: number): IFluidLayoutColumnBuilderImpl<TContent>;
+    static for<TContent>(rowBuilder: IFluidLayoutRowBuilder<TContent>, columnIndex: number): IFluidLayoutColumnBuilder<TContent>;
     // (undocumented)
     protected getColumnFacade: () => IFluidLayoutColumnFacade<TContent>;
     // (undocumented)
@@ -208,7 +208,7 @@ export class FluidLayoutColumnFacade<TContent> implements IFluidLayoutColumnFaca
     // (undocumented)
     contentIs(content: TContent): boolean;
     // (undocumented)
-    static for<TContent>(rowFacade: IFluidLayoutRowFacadeImpl<TContent>, column: IFluidLayoutColumn<TContent>, index: number): IFluidLayoutColumnFacadeImpl<TContent>;
+    static for<TContent>(rowFacade: IFluidLayoutRowFacade<TContent>, column: IFluidLayoutColumn<TContent>, index: number): IFluidLayoutColumnFacade<TContent>;
     // (undocumented)
     hasContent(): boolean;
     // (undocumented)
@@ -226,7 +226,7 @@ export class FluidLayoutColumnFacade<TContent> implements IFluidLayoutColumnFaca
     // (undocumented)
     raw(): IFluidLayoutColumn<TContent>;
     // (undocumented)
-    row(): IFluidLayoutRowFacadeImpl<TContent>;
+    row(): IFluidLayoutRowFacade<TContent>;
     // (undocumented)
     protected readonly rowFacade: IFluidLayoutRowFacade<TContent>;
     // (undocumented)
@@ -262,7 +262,7 @@ export class FluidLayoutColumnsFacade<TContent> implements IFluidLayoutColumnsFa
     // (undocumented)
     flatMap<TReturn>(callback: (column: IFluidLayoutColumnFacade<TContent>) => TReturn[]): TReturn[];
     // (undocumented)
-    static for<TContent>(rowFacade: IFluidLayoutRowFacadeImpl<TContent>, columns: IFluidLayoutColumn<TContent>[]): IFluidLayoutColumnsFacadeImpl<TContent>;
+    static for<TContent>(rowFacade: IFluidLayoutRowFacade<TContent>, columns: IFluidLayoutColumn<TContent>[]): IFluidLayoutColumnsFacade<TContent>;
     // (undocumented)
     map<TReturn>(callback: (column: IFluidLayoutColumnFacade<TContent>) => TReturn): TReturn[];
     // (undocumented)
@@ -279,13 +279,13 @@ export type FluidLayoutColumnsSelector<TContent> = (columnsFacade: IFluidLayoutC
 // @alpha (undocumented)
 export class FluidLayoutFacade<TContent> implements IFluidLayoutFacade<TContent> {
     protected constructor(layout: IFluidLayout<TContent>);
-    static for<TContent>(layout: IFluidLayout<TContent>): IFluidLayoutFacadeImpl<TContent>;
+    static for<TContent>(layout: IFluidLayout<TContent>): IFluidLayoutFacade<TContent>;
     // (undocumented)
     protected layout: IFluidLayout<TContent>;
     // (undocumented)
     raw(): IFluidLayout<TContent>;
     // (undocumented)
-    rows(): IFluidLayoutRowsFacadeImpl<TContent>;
+    rows(): IFluidLayoutRowsFacade<TContent>;
     // (undocumented)
     size(): IFluidLayoutSize | undefined;
 }
@@ -302,7 +302,7 @@ export class FluidLayoutRowBuilder<TContent> implements IFluidLayoutRowBuilder<T
     build(): IFluidLayoutRow<TContent>;
     // (undocumented)
     facade(): IFluidLayoutRowFacade<TContent>;
-    static for<TContent>(layoutBuilder: IFluidLayoutBuilderImpl<TContent>, rowIndex: number): IFluidLayoutRowBuilderImpl<TContent>;
+    static for<TContent>(layoutBuilder: IFluidLayoutBuilder<TContent>, rowIndex: number): IFluidLayoutRowBuilder<TContent>;
     // (undocumented)
     protected getColumnBuilder: (columnIndex: number) => IFluidLayoutColumnBuilder<TContent>;
     // (undocumented)
@@ -337,13 +337,13 @@ export class FluidLayoutRowBuilder<TContent> implements IFluidLayoutRowBuilder<T
 export class FluidLayoutRowFacade<TContent> implements IFluidLayoutRowFacade<TContent> {
     protected constructor(layoutFacade: IFluidLayoutFacade<TContent>, row: IFluidLayoutRow<TContent>, rowIndex: number);
     // (undocumented)
-    columns(): IFluidLayoutColumnsFacadeImpl<TContent>;
+    columns(): IFluidLayoutColumnsFacade<TContent>;
     // (undocumented)
     description(): string | undefined;
     // (undocumented)
     descriptionEquals(description: string): boolean;
     // (undocumented)
-    static for<TContent>(layoutFacade: IFluidLayoutFacadeImpl<TContent>, row: IFluidLayoutRow<TContent>, index: number): IFluidLayoutRowFacadeImpl<TContent>;
+    static for<TContent>(layoutFacade: IFluidLayoutFacade<TContent>, row: IFluidLayoutRow<TContent>, index: number): IFluidLayoutRowFacade<TContent>;
     // (undocumented)
     hasDescription(): boolean;
     // (undocumented)
@@ -365,7 +365,7 @@ export class FluidLayoutRowFacade<TContent> implements IFluidLayoutRowFacade<TCo
     // (undocumented)
     isLast(): boolean;
     // (undocumented)
-    layout(): IFluidLayoutFacadeImpl<TContent>;
+    layout(): IFluidLayoutFacade<TContent>;
     // (undocumented)
     protected readonly layoutFacade: IFluidLayoutFacade<TContent>;
     // (undocumented)
@@ -403,7 +403,7 @@ export class FluidLayoutRowsFacade<TContent> implements IFluidLayoutRowsFacade<T
     // (undocumented)
     flatMap<TReturn>(callback: (row: IFluidLayoutRowFacade<TContent>) => TReturn[]): TReturn[];
     // (undocumented)
-    static for<TContent>(layoutFacade: IFluidLayoutFacadeImpl<TContent>, rows: IFluidLayoutRow<TContent>[]): IFluidLayoutRowsFacadeImpl<TContent>;
+    static for<TContent>(layoutFacade: IFluidLayoutFacade<TContent>, rows: IFluidLayoutRow<TContent>[]): IFluidLayoutRowsFacade<TContent>;
     // (undocumented)
     protected readonly layoutFacade: IFluidLayoutFacade<TContent>;
     // (undocumented)
@@ -1041,9 +1041,6 @@ export interface IFluidLayoutBuilder<TContent> {
     size(valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutSize | undefined>): this;
 }
 
-// @alpha (undocumented)
-export type IFluidLayoutBuilderImpl<TContent> = IFluidLayoutBuilder<TContent>;
-
 // @alpha
 export interface IFluidLayoutColumn<TContent> {
     content?: TContent;
@@ -1059,9 +1056,6 @@ export interface IFluidLayoutColumnBuilder<TContent> {
     setColumn(valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutColumn<TContent>>): this;
     size(valueOrTransform: ValueOrUpdateCallback<IFluidLayoutSizeByScreen>): this;
 }
-
-// @alpha (undocumented)
-export type IFluidLayoutColumnBuilderImpl<TContent> = IFluidLayoutColumnBuilder<TContent>;
 
 // @alpha (undocumented)
 export interface IFluidLayoutColumnFacade<TContent> {
@@ -1100,9 +1094,6 @@ export interface IFluidLayoutColumnFacade<TContent> {
 }
 
 // @alpha (undocumented)
-export type IFluidLayoutColumnFacadeImpl<TContent> = IFluidLayoutColumnFacade<TContent>;
-
-// @alpha (undocumented)
 export interface IFluidLayoutColumnsFacade<TContent> {
     // (undocumented)
     all(): IFluidLayoutColumnFacade<TContent>[];
@@ -1129,9 +1120,6 @@ export interface IFluidLayoutColumnsFacade<TContent> {
 }
 
 // @alpha (undocumented)
-export type IFluidLayoutColumnsFacadeImpl<TContent> = IFluidLayoutColumnsFacade<TContent>;
-
-// @alpha (undocumented)
 export interface IFluidLayoutFacade<TContent> {
     // (undocumented)
     raw(): IFluidLayout<TContent>;
@@ -1140,9 +1128,6 @@ export interface IFluidLayoutFacade<TContent> {
     // (undocumented)
     size(): IFluidLayoutSize | undefined;
 }
-
-// @alpha (undocumented)
-export type IFluidLayoutFacadeImpl<TContent> = IFluidLayoutFacade<TContent>;
 
 // @alpha
 export interface IFluidLayoutRow<TContent> {
@@ -1165,9 +1150,6 @@ export interface IFluidLayoutRowBuilder<TContent> {
     removeEmptyColumns(): this;
     setRow(valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutRow<TContent>>): this;
 }
-
-// @alpha (undocumented)
-export type IFluidLayoutRowBuilderImpl<TContent> = IFluidLayoutRowBuilder<TContent>;
 
 // @alpha (undocumented)
 export interface IFluidLayoutRowFacade<TContent> {
@@ -1212,9 +1194,6 @@ export interface IFluidLayoutRowFacade<TContent> {
 }
 
 // @alpha (undocumented)
-export type IFluidLayoutRowFacadeImpl<TContent> = IFluidLayoutRowFacade<TContent>;
-
-// @alpha (undocumented)
 export interface IFluidLayoutRowsFacade<TContent> {
     // (undocumented)
     all(): IFluidLayoutRowFacade<TContent>[];
@@ -1239,9 +1218,6 @@ export interface IFluidLayoutRowsFacade<TContent> {
     // (undocumented)
     some(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): boolean;
 }
-
-// @alpha (undocumented)
-export type IFluidLayoutRowsFacadeImpl<TContent> = IFluidLayoutRowsFacade<TContent>;
 
 // @alpha
 export interface IFluidLayoutSectionHeader {

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -134,28 +134,28 @@ export type ErrorConverter = (e: Error) => AnalyticalBackendError;
 export type FilterContextItem = IDashboardAttributeFilter | IDashboardDateFilter;
 
 // @alpha (undocumented)
-export class FluidLayoutBuilder<TContent, TLayout extends IFluidLayout<TContent>, TRow extends IFluidLayoutRow<TContent>, TColumn extends IFluidLayoutColumn<TContent>, TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>, TRowsFacade extends IFluidLayoutRowsFacade<TContent, TRow, TRowFacade>, TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>, TColumnsFacade extends IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade>, TLayoutFacade extends IFluidLayoutFacade<TContent, TLayout>, TColumnBuilder extends IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade>, TRowBuilder extends IFluidLayoutRowBuilder<TContent, TRow, TColumn, TRowFacade, TColumnFacade, TColumnsFacade, TColumnBuilder>> implements IFluidLayoutBuilder<TContent, TLayout, TRow, TColumn, TRowFacade, TRowsFacade, TColumnFacade, TColumnsFacade, TLayoutFacade, TColumnBuilder, TRowBuilder> {
-    protected constructor(layoutFacade: TLayoutFacade, layoutFacadeConstructor: (layout: TLayout) => TLayoutFacade, getRowBuilder: (rowIndex: number) => TRowBuilder);
+export class FluidLayoutBuilder<TContent> implements IFluidLayoutBuilder<TContent> {
+    protected constructor(layoutFacade: IFluidLayoutFacade<TContent>, layoutFacadeConstructor: (layout: IFluidLayout<TContent>) => IFluidLayoutFacade<TContent>, getRowBuilder: (rowIndex: number) => IFluidLayoutRowBuilder<TContent>);
     // (undocumented)
-    addRow(create?: FluidLayoutRowModifications<TContent, TColumn, TRow, TRowFacade, TColumnFacade, TColumnsFacade, TColumnBuilder, TRowBuilder>, index?: number): this;
+    addRow(create?: FluidLayoutRowModifications<TContent>, index?: number): this;
     // (undocumented)
-    build(): TLayout;
+    build(): IFluidLayout<TContent>;
     // (undocumented)
-    facade(): TLayoutFacade;
+    facade(): IFluidLayoutFacade<TContent>;
     static for<TContent>(layout: IFluidLayout<TContent>): IFluidLayoutBuilderImpl<TContent>;
     static forNewLayout<TContent>(): IFluidLayoutBuilderImpl<TContent>;
     // (undocumented)
-    protected getRowBuilder: (rowIndex: number) => TRowBuilder;
+    protected getRowBuilder: (rowIndex: number) => IFluidLayoutRowBuilder<TContent>;
     // (undocumented)
-    protected layoutFacade: TLayoutFacade;
+    protected layoutFacade: IFluidLayoutFacade<TContent>;
     // (undocumented)
-    protected layoutFacadeConstructor: (layout: TLayout) => TLayoutFacade;
+    protected layoutFacadeConstructor: (layout: IFluidLayout<TContent>) => IFluidLayoutFacade<TContent>;
     // (undocumented)
-    modify(modifications: FluidLayoutModifications<TContent, TLayout, TRow, TColumn, TRowFacade, TRowsFacade, TColumnFacade, TColumnsFacade, TLayoutFacade, TColumnBuilder, TRowBuilder, this>): this;
+    modify(modifications: FluidLayoutModifications<TContent>): this;
     // (undocumented)
-    modifyRow(index: number, modify: FluidLayoutRowModifications<TContent, TColumn, TRow, TRowFacade, TColumnFacade, TColumnsFacade, TColumnBuilder, TRowBuilder>): this;
+    modifyRow(index: number, modify: FluidLayoutRowModifications<TContent>): this;
     // (undocumented)
-    modifyRows(modify: FluidLayoutRowModifications<TContent, TColumn, TRow, TRowFacade, TColumnFacade, TColumnsFacade, TColumnBuilder, TRowBuilder>, selector?: FluidLayoutRowsSelector<TContent, TRow, TRowFacade, TRowsFacade>): this;
+    modifyRows(modify: FluidLayoutRowModifications<TContent>, selector?: FluidLayoutRowsSelector<TContent>): this;
     // (undocumented)
     moveRow(fromIndex: number, toIndex: number): this;
     // (undocumented)
@@ -163,42 +163,42 @@ export class FluidLayoutBuilder<TContent, TLayout extends IFluidLayout<TContent>
     // (undocumented)
     removeRow(index: number): this;
     // (undocumented)
-    removeRows(selector?: FluidLayoutRowsSelector<TContent, TRow, TRowFacade, TRowsFacade>): this;
+    removeRows(selector?: FluidLayoutRowsSelector<TContent>): this;
     // (undocumented)
-    setLayout: (valueOrUpdateCallback: ValueOrUpdateCallback<TLayout>) => this;
+    setLayout: (valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayout<TContent>>) => this;
     // (undocumented)
     size(valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutSize | undefined>): this;
 }
 
 // @alpha (undocumented)
-export class FluidLayoutColumnBuilder<TContent, TColumn extends IFluidLayoutColumn<TContent>, TRow extends IFluidLayoutRow<TContent>, TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>> implements IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade> {
-    protected constructor(setRow: (valueOrUpdateCallback: ValueOrUpdateCallback<TRow>) => void, getColumnFacade: () => TColumnFacade, columnIndex: number);
+export class FluidLayoutColumnBuilder<TContent> implements IFluidLayoutColumnBuilder<TContent> {
+    protected constructor(setRow: (valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutRow<TContent>>) => void, getColumnFacade: () => IFluidLayoutColumnFacade<TContent>, columnIndex: number);
     // (undocumented)
-    build(): TColumn;
+    build(): IFluidLayoutColumn<TContent>;
     // (undocumented)
     protected columnIndex: number;
     // (undocumented)
     content(valueOrUpdateCallback: ValueOrUpdateCallback<TContent | undefined>): this;
     // (undocumented)
-    facade(): TColumnFacade;
+    facade(): IFluidLayoutColumnFacade<TContent>;
     static for<TContent>(rowBuilder: IFluidLayoutRowBuilderImpl<TContent>, columnIndex: number): IFluidLayoutColumnBuilderImpl<TContent>;
     // (undocumented)
-    protected getColumnFacade: () => TColumnFacade;
+    protected getColumnFacade: () => IFluidLayoutColumnFacade<TContent>;
     // (undocumented)
-    modify(modifications: FluidLayoutColumnModifications<TContent, TColumn, TColumnFacade, this>): this;
+    modify(modifications: FluidLayoutColumnModifications<TContent>): this;
     // (undocumented)
-    setColumn: (valueOrUpdateCallback: ValueOrUpdateCallback<TColumn>) => this;
+    setColumn: (valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutColumn<TContent>>) => this;
     // (undocumented)
-    protected setRow: (valueOrUpdateCallback: ValueOrUpdateCallback<TRow>) => void;
+    protected setRow: (valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutRow<TContent>>) => void;
     // (undocumented)
     size(valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutSizeByScreen>): this;
 }
 
 // @alpha (undocumented)
-export class FluidLayoutColumnFacade<TContent, TColumn extends IFluidLayoutColumn<TContent>, TRow extends IFluidLayoutRow<TContent>, TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>> implements IFluidLayoutColumnFacade<TContent, TColumn> {
-    protected constructor(rowFacade: TRowFacade, column: TColumn, columnIndex: number);
+export class FluidLayoutColumnFacade<TContent> implements IFluidLayoutColumnFacade<TContent> {
+    protected constructor(rowFacade: IFluidLayoutRowFacade<TContent>, column: IFluidLayoutColumn<TContent>, columnIndex: number);
     // (undocumented)
-    protected readonly column: TColumn;
+    protected readonly column: IFluidLayoutColumn<TContent>;
     // (undocumented)
     protected readonly columnIndex: number;
     // (undocumented)
@@ -224,11 +224,11 @@ export class FluidLayoutColumnFacade<TContent, TColumn extends IFluidLayoutColum
     // (undocumented)
     isLastInRow(): boolean;
     // (undocumented)
-    raw(): TColumn;
+    raw(): IFluidLayoutColumn<TContent>;
     // (undocumented)
     row(): IFluidLayoutRowFacadeImpl<TContent>;
     // (undocumented)
-    protected readonly rowFacade: TRowFacade;
+    protected readonly rowFacade: IFluidLayoutRowFacade<TContent>;
     // (undocumented)
     size(): IFluidLayoutSizeByScreen;
     // (undocumented)
@@ -236,54 +236,54 @@ export class FluidLayoutColumnFacade<TContent, TColumn extends IFluidLayoutColum
     // (undocumented)
     test(pred: (column: this) => boolean): boolean;
     // (undocumented)
-    testRaw(pred: (column: TColumn) => boolean): boolean;
+    testRaw(pred: (column: IFluidLayoutColumn<TContent>) => boolean): boolean;
 }
 
 // @alpha
-export type FluidLayoutColumnModifications<TContent, TColumn extends IFluidLayoutColumn<TContent>, TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>, TColumnBuilder extends IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade>> = (columnBuilder: TColumnBuilder, columnFacade: TColumnFacade) => TColumnBuilder;
+export type FluidLayoutColumnModifications<TContent> = (columnBuilder: IFluidLayoutColumnBuilder<TContent>, columnFacade: IFluidLayoutColumnFacade<TContent>) => IFluidLayoutColumnBuilder<TContent>;
 
 // @alpha (undocumented)
-export class FluidLayoutColumnsFacade<TContent, TColumn extends IFluidLayoutColumn<TContent>, TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>> implements IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade> {
-    protected constructor(columnFacades: TColumnFacade[]);
+export class FluidLayoutColumnsFacade<TContent> implements IFluidLayoutColumnsFacade<TContent> {
+    protected constructor(columnFacades: IFluidLayoutColumnFacade<TContent>[]);
     // (undocumented)
-    all(): TColumnFacade[];
+    all(): IFluidLayoutColumnFacade<TContent>[];
     // (undocumented)
-    column(columnIndex: number): TColumnFacade | undefined;
+    column(columnIndex: number): IFluidLayoutColumnFacade<TContent> | undefined;
     // (undocumented)
-    protected readonly columnFacades: TColumnFacade[];
+    protected readonly columnFacades: IFluidLayoutColumnFacade<TContent>[];
     // (undocumented)
     count(): number;
     // (undocumented)
-    every(pred: (row: TColumnFacade) => boolean): boolean;
+    every(pred: (row: IFluidLayoutColumnFacade<TContent>) => boolean): boolean;
     // (undocumented)
-    filter(pred: (row: TColumnFacade) => boolean): TColumnFacade[];
+    filter(pred: (row: IFluidLayoutColumnFacade<TContent>) => boolean): IFluidLayoutColumnFacade<TContent>[];
     // (undocumented)
-    find(pred: (row: TColumnFacade) => boolean): TColumnFacade | undefined;
+    find(pred: (row: IFluidLayoutColumnFacade<TContent>) => boolean): IFluidLayoutColumnFacade<TContent> | undefined;
     // (undocumented)
-    flatMap<TReturn>(callback: (column: TColumnFacade) => TReturn[]): TReturn[];
+    flatMap<TReturn>(callback: (column: IFluidLayoutColumnFacade<TContent>) => TReturn[]): TReturn[];
     // (undocumented)
     static for<TContent>(rowFacade: IFluidLayoutRowFacadeImpl<TContent>, columns: IFluidLayoutColumn<TContent>[]): IFluidLayoutColumnsFacadeImpl<TContent>;
     // (undocumented)
-    map<TReturn>(callback: (column: TColumnFacade) => TReturn): TReturn[];
+    map<TReturn>(callback: (column: IFluidLayoutColumnFacade<TContent>) => TReturn): TReturn[];
     // (undocumented)
-    raw(): TColumn[];
+    raw(): IFluidLayoutColumn<TContent>[];
     // (undocumented)
-    reduce<TReturn>(callback: (acc: TReturn, row: TColumnFacade) => TReturn, initialValue: TReturn): TReturn;
+    reduce<TReturn>(callback: (acc: TReturn, row: IFluidLayoutColumnFacade<TContent>) => TReturn, initialValue: TReturn): TReturn;
     // (undocumented)
-    some(pred: (row: TColumnFacade) => boolean): boolean;
+    some(pred: (row: IFluidLayoutColumnFacade<TContent>) => boolean): boolean;
 }
 
 // @alpha
-export type FluidLayoutColumnsSelector<TContent, TColumn extends IFluidLayoutColumn<TContent>, TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>, TColumnsFacade extends IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade>> = (columnsFacade: TColumnsFacade) => TColumnFacade[] | TColumnFacade | undefined;
+export type FluidLayoutColumnsSelector<TContent> = (columnsFacade: IFluidLayoutColumnsFacade<TContent>) => IFluidLayoutColumnFacade<TContent>[] | IFluidLayoutColumnFacade<TContent> | undefined;
 
 // @alpha (undocumented)
-export class FluidLayoutFacade<TContent, TLayout extends IFluidLayout<TContent>> implements IFluidLayoutFacade<TContent, TLayout> {
-    protected constructor(layout: TLayout);
+export class FluidLayoutFacade<TContent> implements IFluidLayoutFacade<TContent> {
+    protected constructor(layout: IFluidLayout<TContent>);
     static for<TContent>(layout: IFluidLayout<TContent>): IFluidLayoutFacadeImpl<TContent>;
     // (undocumented)
-    protected layout: TLayout;
+    protected layout: IFluidLayout<TContent>;
     // (undocumented)
-    raw(): TLayout;
+    raw(): IFluidLayout<TContent>;
     // (undocumented)
     rows(): IFluidLayoutRowsFacadeImpl<TContent>;
     // (undocumented)
@@ -291,51 +291,51 @@ export class FluidLayoutFacade<TContent, TLayout extends IFluidLayout<TContent>>
 }
 
 // @alpha
-export type FluidLayoutModifications<TContent, TLayout extends IFluidLayout<TContent>, TRow extends IFluidLayoutRow<TContent>, TColumn extends IFluidLayoutColumn<TContent>, TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>, TRowsFacade extends IFluidLayoutRowsFacade<TContent, TRow, TRowFacade>, TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>, TColumnsFacade extends IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade>, TLayoutFacade extends IFluidLayoutFacade<TContent, TLayout>, TColumnBuilder extends IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade>, TRowBuilder extends IFluidLayoutRowBuilder<TContent, TRow, TColumn, TRowFacade, TColumnFacade, TColumnsFacade, TColumnBuilder>, TLayoutBuilder extends IFluidLayoutBuilder<TContent, TLayout, TRow, TColumn, TRowFacade, TRowsFacade, TColumnFacade, TColumnsFacade, TLayoutFacade, TColumnBuilder, TRowBuilder>> = (layoutBuilder: TLayoutBuilder, layoutFacade: TLayoutFacade) => TLayoutBuilder;
+export type FluidLayoutModifications<TContent> = (layoutBuilder: IFluidLayoutBuilder<TContent>, layoutFacade: IFluidLayoutFacade<TContent>) => IFluidLayoutBuilder<TContent>;
 
 // @alpha (undocumented)
-export class FluidLayoutRowBuilder<TContent, TRow extends IFluidLayoutRow<TContent>, TColumn extends IFluidLayoutColumn<TContent>, TLayout extends IFluidLayout<TContent>, TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>, TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>, TColumnsFacade extends IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade>, TColumnBuilder extends IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade>> implements IFluidLayoutRowBuilder<TContent, TRow, TColumn, TRowFacade, TColumnFacade, TColumnsFacade, TColumnBuilder> {
-    protected constructor(rowIndex: number, setLayout: (valueOrUpdateCallback: ValueOrUpdateCallback<TLayout>) => void, getRowFacade: () => TRowFacade, getColumnsFacade: () => TColumnsFacade, getColumnBuilder: (columnIndex: number) => TColumnBuilder);
+export class FluidLayoutRowBuilder<TContent> implements IFluidLayoutRowBuilder<TContent> {
+    protected constructor(rowIndex: number, setLayout: (valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayout<TContent>>) => void, getRowFacade: () => IFluidLayoutRowFacade<TContent>, getColumnsFacade: () => IFluidLayoutColumnsFacade<TContent>, getColumnBuilder: (columnIndex: number) => IFluidLayoutColumnBuilder<TContent>);
     // (undocumented)
-    addColumn(xlSize: IFluidLayoutSize, create?: (builder: TColumnBuilder) => TColumnBuilder, index?: number): this;
+    addColumn(xlSize: IFluidLayoutSize, create?: (builder: IFluidLayoutColumnBuilder<TContent>) => IFluidLayoutColumnBuilder<TContent>, index?: number): this;
     // (undocumented)
-    build(): TRow;
+    build(): IFluidLayoutRow<TContent>;
     // (undocumented)
-    facade(): TRowFacade;
+    facade(): IFluidLayoutRowFacade<TContent>;
     static for<TContent>(layoutBuilder: IFluidLayoutBuilderImpl<TContent>, rowIndex: number): IFluidLayoutRowBuilderImpl<TContent>;
     // (undocumented)
-    protected getColumnBuilder: (columnIndex: number) => TColumnBuilder;
+    protected getColumnBuilder: (columnIndex: number) => IFluidLayoutColumnBuilder<TContent>;
     // (undocumented)
-    protected getColumnsFacade: () => TColumnsFacade;
+    protected getColumnsFacade: () => IFluidLayoutColumnsFacade<TContent>;
     // (undocumented)
-    protected getRowFacade: () => TRowFacade;
+    protected getRowFacade: () => IFluidLayoutRowFacade<TContent>;
     // (undocumented)
     header(valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutSectionHeader | undefined>): this;
     // (undocumented)
-    modify(modifications: FluidLayoutRowModifications<TContent, TColumn, TRow, TRowFacade, TColumnFacade, TColumnsFacade, TColumnBuilder, this>): this;
+    modify(modifications: FluidLayoutRowModifications<TContent>): this;
     // (undocumented)
-    modifyColumn(index: number, modify: FluidLayoutColumnModifications<TContent, TColumn, TColumnFacade, TColumnBuilder>): this;
+    modifyColumn(index: number, modify: FluidLayoutColumnModifications<TContent>): this;
     // (undocumented)
-    modifyColumns(modify: FluidLayoutColumnModifications<TContent, TColumn, TColumnFacade, TColumnBuilder>, selector?: FluidLayoutColumnsSelector<TContent, TColumn, TColumnFacade, TColumnsFacade>): this;
+    modifyColumns(modify: FluidLayoutColumnModifications<TContent>, selector?: FluidLayoutColumnsSelector<TContent>): this;
     // (undocumented)
     moveColumn(fromIndex: number, toIndex: number): this;
     // (undocumented)
     removeColumn(index: number): this;
     // (undocumented)
-    removeColumns(selector?: FluidLayoutColumnsSelector<TContent, TColumn, TColumnFacade, TColumnsFacade>): this;
+    removeColumns(selector?: FluidLayoutColumnsSelector<TContent>): this;
     // (undocumented)
     removeEmptyColumns: () => this;
     // (undocumented)
     protected rowIndex: number;
     // (undocumented)
-    protected setLayout: (valueOrUpdateCallback: ValueOrUpdateCallback<TLayout>) => void;
+    protected setLayout: (valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayout<TContent>>) => void;
     // (undocumented)
-    setRow: (valueOrUpdateCallback: ValueOrUpdateCallback<TRow>) => this;
+    setRow: (valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutRow<TContent>>) => this;
 }
 
 // @alpha (undocumented)
-export class FluidLayoutRowFacade<TContent, TRow extends IFluidLayoutRow<TContent>, TLayout extends IFluidLayout<TContent>, TLayoutFacade extends IFluidLayoutFacade<TContent, TLayout>> implements IFluidLayoutRowFacade<TContent, TRow> {
-    protected constructor(layoutFacade: TLayoutFacade, row: TRow, rowIndex: number);
+export class FluidLayoutRowFacade<TContent> implements IFluidLayoutRowFacade<TContent> {
+    protected constructor(layoutFacade: IFluidLayoutFacade<TContent>, row: IFluidLayoutRow<TContent>, rowIndex: number);
     // (undocumented)
     columns(): IFluidLayoutColumnsFacadeImpl<TContent>;
     // (undocumented)
@@ -367,17 +367,17 @@ export class FluidLayoutRowFacade<TContent, TRow extends IFluidLayoutRow<TConten
     // (undocumented)
     layout(): IFluidLayoutFacadeImpl<TContent>;
     // (undocumented)
-    protected readonly layoutFacade: TLayoutFacade;
+    protected readonly layoutFacade: IFluidLayoutFacade<TContent>;
     // (undocumented)
-    raw(): TRow;
+    raw(): IFluidLayoutRow<TContent>;
     // (undocumented)
-    protected readonly row: TRow;
+    protected readonly row: IFluidLayoutRow<TContent>;
     // (undocumented)
     protected readonly rowIndex: number;
     // (undocumented)
     test(pred: (row: this) => boolean): boolean;
     // (undocumented)
-    testRaw(pred: (row: TRow) => boolean): boolean;
+    testRaw(pred: (row: IFluidLayoutRow<TContent>) => boolean): boolean;
     // (undocumented)
     title(): string | undefined;
     // (undocumented)
@@ -385,43 +385,43 @@ export class FluidLayoutRowFacade<TContent, TRow extends IFluidLayoutRow<TConten
 }
 
 // @alpha
-export type FluidLayoutRowModifications<TContent, TColumn extends IFluidLayoutColumn<TContent>, TRow extends IFluidLayoutRow<TContent>, TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>, TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>, TColumnsFacade extends IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade>, TColumnBuilder extends IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade>, TRowBuilder extends IFluidLayoutRowBuilder<TContent, TRow, TColumn, TRowFacade, TColumnFacade, TColumnsFacade, TColumnBuilder>> = (rowBuilder: TRowBuilder, rowFacade: TRowFacade) => TRowBuilder;
+export type FluidLayoutRowModifications<TContent> = (rowBuilder: IFluidLayoutRowBuilder<TContent>, rowFacade: IFluidLayoutRowFacade<TContent>) => IFluidLayoutRowBuilder<TContent>;
 
 // @alpha (undocumented)
-export class FluidLayoutRowsFacade<TContent, TRow extends IFluidLayoutRow<TContent>, TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>, TLayout extends IFluidLayout<TContent>, TLayoutFacade extends IFluidLayoutFacade<TContent, TLayout>> implements IFluidLayoutRowsFacade<TContent, TRow, TRowFacade> {
-    protected constructor(layoutFacade: TLayoutFacade, rowFacades: TRowFacade[]);
+export class FluidLayoutRowsFacade<TContent> implements IFluidLayoutRowsFacade<TContent> {
+    protected constructor(layoutFacade: IFluidLayoutFacade<TContent>, rowFacades: IFluidLayoutRowFacade<TContent>[]);
     // (undocumented)
-    all(): TRowFacade[];
+    all(): IFluidLayoutRowFacade<TContent>[];
     // (undocumented)
     count(): number;
     // (undocumented)
-    every(pred: (row: TRowFacade) => boolean): boolean;
+    every(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): boolean;
     // (undocumented)
-    filter(pred: (row: TRowFacade) => boolean): TRowFacade[];
+    filter(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): IFluidLayoutRowFacade<TContent>[];
     // (undocumented)
-    find(pred: (row: TRowFacade) => boolean): TRowFacade | undefined;
+    find(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): IFluidLayoutRowFacade<TContent> | undefined;
     // (undocumented)
-    flatMap<TReturn>(callback: (row: TRowFacade) => TReturn[]): TReturn[];
+    flatMap<TReturn>(callback: (row: IFluidLayoutRowFacade<TContent>) => TReturn[]): TReturn[];
     // (undocumented)
     static for<TContent>(layoutFacade: IFluidLayoutFacadeImpl<TContent>, rows: IFluidLayoutRow<TContent>[]): IFluidLayoutRowsFacadeImpl<TContent>;
     // (undocumented)
-    protected readonly layoutFacade: TLayoutFacade;
+    protected readonly layoutFacade: IFluidLayoutFacade<TContent>;
     // (undocumented)
-    map<TReturn>(callback: (row: TRowFacade) => TReturn): TReturn[];
+    map<TReturn>(callback: (row: IFluidLayoutRowFacade<TContent>) => TReturn): TReturn[];
     // (undocumented)
-    raw(): TRow[];
+    raw(): IFluidLayoutRow<TContent>[];
     // (undocumented)
-    reduce<TReturn>(callback: (acc: TReturn, row: TRowFacade) => TReturn, initialValue: TReturn): TReturn;
+    reduce<TReturn>(callback: (acc: TReturn, row: IFluidLayoutRowFacade<TContent>) => TReturn, initialValue: TReturn): TReturn;
     // (undocumented)
-    row(rowIndex: number): TRowFacade | undefined;
+    row(rowIndex: number): IFluidLayoutRowFacade<TContent> | undefined;
     // (undocumented)
-    protected readonly rowFacades: TRowFacade[];
+    protected readonly rowFacades: IFluidLayoutRowFacade<TContent>[];
     // (undocumented)
-    some(pred: (row: TRowFacade) => boolean): boolean;
+    some(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): boolean;
 }
 
 // @alpha
-export type FluidLayoutRowsSelector<TContent, TRow extends IFluidLayoutRow<TContent>, TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>, TRowsFacade extends IFluidLayoutRowsFacade<TContent, TRow, TRowFacade>> = (rowsFacade: TRowsFacade) => TRowFacade[] | TRowFacade | undefined;
+export type FluidLayoutRowsSelector<TContent> = (rowsFacade: IFluidLayoutRowsFacade<TContent>) => IFluidLayoutRowFacade<TContent>[] | IFluidLayoutRowFacade<TContent> | undefined;
 
 // @public
 export type GroupableCatalogItem = ICatalogAttribute | ICatalogMeasure | ICatalogFact;
@@ -1026,23 +1026,23 @@ export interface IFluidLayout<TContent> {
 }
 
 // @alpha
-export interface IFluidLayoutBuilder<TContent, TLayout extends IFluidLayout<TContent>, TRow extends IFluidLayoutRow<TContent>, TColumn extends IFluidLayoutColumn<TContent>, TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>, TRowsFacade extends IFluidLayoutRowsFacade<TContent, TRow, TRowFacade>, TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>, TColumnsFacade extends IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade>, TLayoutFacade extends IFluidLayoutFacade<TContent, TLayout>, TColumnBuilder extends IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade>, TRowBuilder extends IFluidLayoutRowBuilder<TContent, TRow, TColumn, TRowFacade, TColumnFacade, TColumnsFacade, TColumnBuilder>> {
-    addRow(create?: (builder: TRowBuilder) => TRowBuilder, index?: number): this;
-    build(): TLayout;
-    facade(): TLayoutFacade;
-    modify(modifications: FluidLayoutModifications<TContent, TLayout, TRow, TColumn, TRowFacade, TRowsFacade, TColumnFacade, TColumnsFacade, TLayoutFacade, TColumnBuilder, TRowBuilder, this>): this;
-    modifyRow(index: number, modify: FluidLayoutRowModifications<TContent, TColumn, TRow, TRowFacade, TColumnFacade, TColumnsFacade, TColumnBuilder, TRowBuilder>): this;
-    modifyRows(modify: FluidLayoutRowModifications<TContent, TColumn, TRow, TRowFacade, TColumnFacade, TColumnsFacade, TColumnBuilder, TRowBuilder>, selector?: FluidLayoutRowsSelector<TContent, TRow, TRowFacade, TRowsFacade>): this;
+export interface IFluidLayoutBuilder<TContent> {
+    addRow(create?: (builder: IFluidLayoutRowBuilder<TContent>) => IFluidLayoutRowBuilder<TContent>, index?: number): this;
+    build(): IFluidLayout<TContent>;
+    facade(): IFluidLayoutFacade<TContent>;
+    modify(modifications: FluidLayoutModifications<TContent>): this;
+    modifyRow(index: number, modify: FluidLayoutRowModifications<TContent>): this;
+    modifyRows(modify: FluidLayoutRowModifications<TContent>, selector?: FluidLayoutRowsSelector<TContent>): this;
     moveRow(fromIndex: number, toIndex: number): this;
     removeEmptyRows(): this;
     removeRow(index: number): this;
-    removeRows(selector?: FluidLayoutRowsSelector<TContent, TRow, TRowFacade, TRowsFacade>): this;
-    setLayout(valueOrUpdateCallback: ValueOrUpdateCallback<TLayout>): this;
+    removeRows(selector?: FluidLayoutRowsSelector<TContent>): this;
+    setLayout(valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayout<TContent>>): this;
     size(valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutSize | undefined>): this;
 }
 
 // @alpha (undocumented)
-export type IFluidLayoutBuilderImpl<TContent> = IFluidLayoutBuilder<TContent, IFluidLayout<TContent>, IFluidLayoutRow<TContent>, IFluidLayoutColumn<TContent>, IFluidLayoutRowFacadeImpl<TContent>, IFluidLayoutRowsFacadeImpl<TContent>, IFluidLayoutColumnFacadeImpl<TContent>, IFluidLayoutColumnsFacadeImpl<TContent>, IFluidLayoutFacadeImpl<TContent>, IFluidLayoutColumnBuilderImpl<TContent>, IFluidLayoutRowBuilderImpl<TContent>>;
+export type IFluidLayoutBuilderImpl<TContent> = IFluidLayoutBuilder<TContent>;
 
 // @alpha
 export interface IFluidLayoutColumn<TContent> {
@@ -1051,20 +1051,20 @@ export interface IFluidLayoutColumn<TContent> {
 }
 
 // @alpha
-export interface IFluidLayoutColumnBuilder<TContent, TColumn extends IFluidLayoutColumn<TContent>, TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>> {
-    build(): TColumn;
+export interface IFluidLayoutColumnBuilder<TContent> {
+    build(): IFluidLayoutColumn<TContent>;
     content(valueOrTransform: ValueOrUpdateCallback<TContent | undefined>): this;
-    facade(): TColumnFacade;
-    modify(modifications: FluidLayoutColumnModifications<TContent, TColumn, TColumnFacade, this>): this;
-    setColumn(valueOrUpdateCallback: ValueOrUpdateCallback<TColumn>): this;
+    facade(): IFluidLayoutColumnFacade<TContent>;
+    modify(modifications: FluidLayoutColumnModifications<TContent>): this;
+    setColumn(valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutColumn<TContent>>): this;
     size(valueOrTransform: ValueOrUpdateCallback<IFluidLayoutSizeByScreen>): this;
 }
 
 // @alpha (undocumented)
-export type IFluidLayoutColumnBuilderImpl<TContent> = IFluidLayoutColumnBuilder<TContent, IFluidLayoutColumn<TContent>, IFluidLayoutColumnFacadeImpl<TContent>>;
+export type IFluidLayoutColumnBuilderImpl<TContent> = IFluidLayoutColumnBuilder<TContent>;
 
 // @alpha (undocumented)
-export interface IFluidLayoutColumnFacade<TContent, TColumn extends IFluidLayoutColumn<TContent>> {
+export interface IFluidLayoutColumnFacade<TContent> {
     // (undocumented)
     content(): TContent | undefined;
     // (undocumented)
@@ -1086,9 +1086,9 @@ export interface IFluidLayoutColumnFacade<TContent, TColumn extends IFluidLayout
     // (undocumented)
     isLastInRow(): boolean;
     // (undocumented)
-    raw(): TColumn;
+    raw(): IFluidLayoutColumn<TContent>;
     // (undocumented)
-    row(): IFluidLayoutRowFacade<TContent, IFluidLayoutRow<TContent>>;
+    row(): IFluidLayoutRowFacade<TContent>;
     // (undocumented)
     size(): IFluidLayoutSizeByScreen;
     // (undocumented)
@@ -1096,53 +1096,53 @@ export interface IFluidLayoutColumnFacade<TContent, TColumn extends IFluidLayout
     // (undocumented)
     test(pred: (column: this) => boolean): boolean;
     // (undocumented)
-    testRaw(pred: (column: TColumn) => boolean): boolean;
+    testRaw(pred: (column: IFluidLayoutColumn<TContent>) => boolean): boolean;
 }
 
 // @alpha (undocumented)
-export type IFluidLayoutColumnFacadeImpl<TContent> = IFluidLayoutColumnFacade<TContent, IFluidLayoutColumn<TContent>>;
+export type IFluidLayoutColumnFacadeImpl<TContent> = IFluidLayoutColumnFacade<TContent>;
 
 // @alpha (undocumented)
-export interface IFluidLayoutColumnsFacade<TContent, TColumn extends IFluidLayoutColumn<TContent>, TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>> {
+export interface IFluidLayoutColumnsFacade<TContent> {
     // (undocumented)
-    all(): TColumnFacade[];
+    all(): IFluidLayoutColumnFacade<TContent>[];
     // (undocumented)
-    column(columnIndex: number): TColumnFacade | undefined;
+    column(columnIndex: number): IFluidLayoutColumnFacade<TContent> | undefined;
     // (undocumented)
     count(): number;
     // (undocumented)
-    every(pred: (column: TColumnFacade) => boolean): boolean;
+    every(pred: (column: IFluidLayoutColumnFacade<TContent>) => boolean): boolean;
     // (undocumented)
-    filter(pred: (row: TColumnFacade) => boolean): TColumnFacade[];
+    filter(pred: (row: IFluidLayoutColumnFacade<TContent>) => boolean): IFluidLayoutColumnFacade<TContent>[];
     // (undocumented)
-    find(pred: (column: TColumnFacade) => boolean): TColumnFacade | undefined;
+    find(pred: (column: IFluidLayoutColumnFacade<TContent>) => boolean): IFluidLayoutColumnFacade<TContent> | undefined;
     // (undocumented)
-    flatMap<TReturn>(callback: (row: TColumnFacade) => TReturn[]): TReturn[];
+    flatMap<TReturn>(callback: (row: IFluidLayoutColumnFacade<TContent>) => TReturn[]): TReturn[];
     // (undocumented)
-    map<TReturn>(callback: (column: TColumnFacade) => TReturn): TReturn[];
+    map<TReturn>(callback: (column: IFluidLayoutColumnFacade<TContent>) => TReturn): TReturn[];
     // (undocumented)
-    raw(): TColumn[];
+    raw(): IFluidLayoutColumn<TContent>[];
     // (undocumented)
-    reduce<TReturn>(callback: (acc: TReturn, column: TColumnFacade) => TReturn, initialValue: TReturn): TReturn;
+    reduce<TReturn>(callback: (acc: TReturn, column: IFluidLayoutColumnFacade<TContent>) => TReturn, initialValue: TReturn): TReturn;
     // (undocumented)
-    some(pred: (column: TColumnFacade) => boolean): boolean;
+    some(pred: (column: IFluidLayoutColumnFacade<TContent>) => boolean): boolean;
 }
 
 // @alpha (undocumented)
-export type IFluidLayoutColumnsFacadeImpl<TContent> = IFluidLayoutColumnsFacade<TContent, IFluidLayoutColumn<TContent>, IFluidLayoutColumnFacadeImpl<TContent>>;
+export type IFluidLayoutColumnsFacadeImpl<TContent> = IFluidLayoutColumnsFacade<TContent>;
 
 // @alpha (undocumented)
-export interface IFluidLayoutFacade<TContent, TLayout extends IFluidLayout<TContent>> {
+export interface IFluidLayoutFacade<TContent> {
     // (undocumented)
-    raw(): TLayout;
+    raw(): IFluidLayout<TContent>;
     // (undocumented)
-    rows(): IFluidLayoutRowsFacade<TContent, IFluidLayoutRow<TContent>, IFluidLayoutRowFacade<TContent, IFluidLayoutRow<TContent>>>;
+    rows(): IFluidLayoutRowsFacade<TContent>;
     // (undocumented)
     size(): IFluidLayoutSize | undefined;
 }
 
 // @alpha (undocumented)
-export type IFluidLayoutFacadeImpl<TContent> = IFluidLayoutFacade<TContent, IFluidLayout<TContent>>;
+export type IFluidLayoutFacadeImpl<TContent> = IFluidLayoutFacade<TContent>;
 
 // @alpha
 export interface IFluidLayoutRow<TContent> {
@@ -1151,28 +1151,28 @@ export interface IFluidLayoutRow<TContent> {
 }
 
 // @alpha
-export interface IFluidLayoutRowBuilder<TContent, TRow extends IFluidLayoutRow<TContent>, TColumn extends IFluidLayoutColumn<TContent>, TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>, TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>, TColumnsFacade extends IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade>, TColumnBuilder extends IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade>> {
-    addColumn(xlSize: IFluidLayoutSize, create?: (builder: TColumnBuilder) => TColumnBuilder, index?: number): this;
-    build(): TRow;
-    facade(): TRowFacade;
+export interface IFluidLayoutRowBuilder<TContent> {
+    addColumn(xlSize: IFluidLayoutSize, create?: (builder: IFluidLayoutColumnBuilder<TContent>) => IFluidLayoutColumnBuilder<TContent>, index?: number): this;
+    build(): IFluidLayoutRow<TContent>;
+    facade(): IFluidLayoutRowFacade<TContent>;
     header(valueOrTransform: ValueOrUpdateCallback<IFluidLayoutSectionHeader | undefined>): this;
-    modify(modifications: FluidLayoutRowModifications<TContent, TColumn, TRow, TRowFacade, TColumnFacade, TColumnsFacade, TColumnBuilder, this>): this;
-    modifyColumn(index: number, modify: FluidLayoutColumnModifications<TContent, TColumn, TColumnFacade, TColumnBuilder>): this;
-    modifyColumns(modify: FluidLayoutColumnModifications<TContent, TColumn, TColumnFacade, TColumnBuilder>, selector?: FluidLayoutColumnsSelector<TContent, TColumn, TColumnFacade, TColumnsFacade>): this;
+    modify(modifications: FluidLayoutRowModifications<TContent>): this;
+    modifyColumn(index: number, modify: FluidLayoutColumnModifications<TContent>): this;
+    modifyColumns(modify: FluidLayoutColumnModifications<TContent>, selector?: FluidLayoutColumnsSelector<TContent>): this;
     moveColumn(fromIndex: number, toIndex: number): this;
     removeColumn(index: number): this;
-    removeColumns(selector?: FluidLayoutColumnsSelector<TContent, TColumn, TColumnFacade, TColumnsFacade>): this;
+    removeColumns(selector?: FluidLayoutColumnsSelector<TContent>): this;
     removeEmptyColumns(): this;
-    setRow(valueOrUpdateCallback: ValueOrUpdateCallback<TRow>): this;
+    setRow(valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutRow<TContent>>): this;
 }
 
 // @alpha (undocumented)
-export type IFluidLayoutRowBuilderImpl<TContent> = IFluidLayoutRowBuilder<TContent, IFluidLayoutRow<TContent>, IFluidLayoutColumn<TContent>, IFluidLayoutRowFacadeImpl<TContent>, IFluidLayoutColumnFacadeImpl<TContent>, IFluidLayoutColumnsFacadeImpl<TContent>, IFluidLayoutColumnBuilderImpl<TContent>>;
+export type IFluidLayoutRowBuilderImpl<TContent> = IFluidLayoutRowBuilder<TContent>;
 
 // @alpha (undocumented)
-export interface IFluidLayoutRowFacade<TContent, TRow extends IFluidLayoutRow<TContent>> {
+export interface IFluidLayoutRowFacade<TContent> {
     // (undocumented)
-    columns(): IFluidLayoutColumnsFacade<TContent, IFluidLayoutColumn<TContent>, IFluidLayoutColumnFacade<TContent, IFluidLayoutColumn<TContent>>>;
+    columns(): IFluidLayoutColumnsFacade<TContent>;
     // (undocumented)
     description(): string | undefined;
     // (undocumented)
@@ -1198,13 +1198,13 @@ export interface IFluidLayoutRowFacade<TContent, TRow extends IFluidLayoutRow<TC
     // (undocumented)
     isLast(): boolean;
     // (undocumented)
-    layout(): IFluidLayoutFacade<TContent, IFluidLayout<TContent>>;
+    layout(): IFluidLayoutFacade<TContent>;
     // (undocumented)
-    raw(): TRow;
+    raw(): IFluidLayoutRow<TContent>;
     // (undocumented)
     test(pred: (column: this) => boolean): boolean;
     // (undocumented)
-    testRaw(pred: (column: TRow) => boolean): boolean;
+    testRaw(pred: (column: IFluidLayoutRow<TContent>) => boolean): boolean;
     // (undocumented)
     title(): string | undefined;
     // (undocumented)
@@ -1212,36 +1212,36 @@ export interface IFluidLayoutRowFacade<TContent, TRow extends IFluidLayoutRow<TC
 }
 
 // @alpha (undocumented)
-export type IFluidLayoutRowFacadeImpl<TContent> = IFluidLayoutRowFacade<TContent, IFluidLayoutRow<TContent>>;
+export type IFluidLayoutRowFacadeImpl<TContent> = IFluidLayoutRowFacade<TContent>;
 
 // @alpha (undocumented)
-export interface IFluidLayoutRowsFacade<TContent, TRow extends IFluidLayoutRow<TContent>, TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>> {
+export interface IFluidLayoutRowsFacade<TContent> {
     // (undocumented)
-    all(): TRowFacade[];
+    all(): IFluidLayoutRowFacade<TContent>[];
     // (undocumented)
     count(): number;
     // (undocumented)
-    every(pred: (row: TRowFacade) => boolean): boolean;
+    every(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): boolean;
     // (undocumented)
-    filter(pred: (row: TRowFacade) => boolean): TRowFacade[];
+    filter(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): IFluidLayoutRowFacade<TContent>[];
     // (undocumented)
-    find(pred: (row: TRowFacade) => boolean): TRowFacade | undefined;
+    find(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): IFluidLayoutRowFacade<TContent> | undefined;
     // (undocumented)
-    flatMap<TReturn>(callback: (row: TRowFacade) => TReturn[]): TReturn[];
+    flatMap<TReturn>(callback: (row: IFluidLayoutRowFacade<TContent>) => TReturn[]): TReturn[];
     // (undocumented)
-    map<TReturn>(callback: (row: TRowFacade) => TReturn): TReturn[];
+    map<TReturn>(callback: (row: IFluidLayoutRowFacade<TContent>) => TReturn): TReturn[];
     // (undocumented)
-    raw(): TRow[];
+    raw(): IFluidLayoutRow<TContent>[];
     // (undocumented)
-    reduce<TReturn>(callback: (acc: TReturn, row: TRowFacade) => TReturn, initialValue: TReturn): TReturn;
+    reduce<TReturn>(callback: (acc: TReturn, row: IFluidLayoutRowFacade<TContent>) => TReturn, initialValue: TReturn): TReturn;
     // (undocumented)
-    row(rowIndex: number): TRowFacade | undefined;
+    row(rowIndex: number): IFluidLayoutRowFacade<TContent> | undefined;
     // (undocumented)
-    some(pred: (row: TRowFacade) => boolean): boolean;
+    some(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): boolean;
 }
 
 // @alpha (undocumented)
-export type IFluidLayoutRowsFacadeImpl<TContent> = IFluidLayoutRowsFacade<TContent, IFluidLayoutRow<TContent>, IFluidLayoutRowFacadeImpl<TContent>>;
+export type IFluidLayoutRowsFacadeImpl<TContent> = IFluidLayoutRowsFacade<TContent>;
 
 // @alpha
 export interface IFluidLayoutSectionHeader {

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -246,9 +246,6 @@ export {
     IFluidLayoutColumnBuilder,
     IFluidLayoutRowBuilder,
     ValueOrUpdateCallback,
-    IFluidLayoutBuilderImpl,
-    IFluidLayoutColumnBuilderImpl,
-    IFluidLayoutRowBuilderImpl,
 } from "./workspace/dashboards/layout/builder/interfaces";
 export { resolveValueOrUpdateCallback } from "./workspace/dashboards/layout/builder/utils";
 export {
@@ -265,11 +262,6 @@ export {
     IFluidLayoutColumnsFacade,
     IFluidLayoutRowFacade,
     IFluidLayoutRowsFacade,
-    IFluidLayoutColumnFacadeImpl,
-    IFluidLayoutColumnsFacadeImpl,
-    IFluidLayoutFacadeImpl,
-    IFluidLayoutRowFacadeImpl,
-    IFluidLayoutRowsFacadeImpl,
 } from "./workspace/dashboards/layout/facade/interfaces";
 export {
     IWidget,

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/column.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/column.ts
@@ -10,11 +10,10 @@ import {
 import {
     FluidLayoutColumnModifications,
     IFluidLayoutColumnBuilder,
-    IFluidLayoutColumnBuilderImpl,
+    IFluidLayoutRowBuilder,
     ValueOrUpdateCallback,
 } from "./interfaces";
 import { resolveValueOrUpdateCallback } from "./utils";
-import { IFluidLayoutRowBuilderImpl } from "./interfaces";
 
 /**
  * @alpha
@@ -32,9 +31,9 @@ export class FluidLayoutColumnBuilder<TContent> implements IFluidLayoutColumnBui
      * @param column - column to modify
      */
     public static for<TContent>(
-        rowBuilder: IFluidLayoutRowBuilderImpl<TContent>,
+        rowBuilder: IFluidLayoutRowBuilder<TContent>,
         columnIndex: number,
-    ): IFluidLayoutColumnBuilderImpl<TContent> {
+    ): IFluidLayoutColumnBuilder<TContent> {
         invariant(
             isFluidLayoutColumn(rowBuilder.facade().columns().column(columnIndex)?.raw()),
             "Provided data must be IFluidLayoutColumn!",

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/column.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/column.ts
@@ -19,15 +19,10 @@ import { IFluidLayoutRowBuilderImpl } from "./interfaces";
 /**
  * @alpha
  */
-export class FluidLayoutColumnBuilder<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TRow extends IFluidLayoutRow<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
-> implements IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade> {
+export class FluidLayoutColumnBuilder<TContent> implements IFluidLayoutColumnBuilder<TContent> {
     protected constructor(
-        protected setRow: (valueOrUpdateCallback: ValueOrUpdateCallback<TRow>) => void,
-        protected getColumnFacade: () => TColumnFacade,
+        protected setRow: (valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutRow<TContent>>) => void,
+        protected getColumnFacade: () => IFluidLayoutColumnFacade<TContent>,
         protected columnIndex: number,
     ) {}
 
@@ -67,7 +62,7 @@ export class FluidLayoutColumnBuilder<
         return this;
     }
 
-    public setColumn = (valueOrUpdateCallback: ValueOrUpdateCallback<TColumn>): this => {
+    public setColumn = (valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutColumn<TContent>>): this => {
         this.setRow((row) => {
             const updatedColumns = [...row.columns];
             updatedColumns[this.columnIndex] = resolveValueOrUpdateCallback(
@@ -82,18 +77,16 @@ export class FluidLayoutColumnBuilder<
         return this;
     };
 
-    public modify(
-        modifications: FluidLayoutColumnModifications<TContent, TColumn, TColumnFacade, this>,
-    ): this {
+    public modify(modifications: FluidLayoutColumnModifications<TContent>): this {
         modifications(this, this.facade());
         return this;
     }
 
-    public build(): TColumn {
+    public build(): IFluidLayoutColumn<TContent> {
         return this.facade().raw();
     }
 
-    public facade(): TColumnFacade {
+    public facade(): IFluidLayoutColumnFacade<TContent> {
         return this.getColumnFacade();
     }
 }

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/interfaces.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/interfaces.ts
@@ -9,15 +9,10 @@ import {
 } from "../fluidLayout";
 import {
     IFluidLayoutColumnFacade,
-    IFluidLayoutColumnFacadeImpl,
     IFluidLayoutColumnsFacade,
-    IFluidLayoutColumnsFacadeImpl,
     IFluidLayoutFacade,
-    IFluidLayoutFacadeImpl,
     IFluidLayoutRowFacade,
-    IFluidLayoutRowFacadeImpl,
     IFluidLayoutRowsFacade,
-    IFluidLayoutRowsFacadeImpl,
 } from "../facade/interfaces";
 
 /**
@@ -27,12 +22,9 @@ import {
  * @param rowsFacade - rows facade to create a query
  * @returns array of row facades, single row facade, or undefined
  */
-export type FluidLayoutRowsSelector<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>,
-    TRowsFacade extends IFluidLayoutRowsFacade<TContent, TRow, TRowFacade>
-> = (rowsFacade: TRowsFacade) => TRowFacade[] | TRowFacade | undefined;
+export type FluidLayoutRowsSelector<TContent> = (
+    rowsFacade: IFluidLayoutRowsFacade<TContent>,
+) => IFluidLayoutRowFacade<TContent>[] | IFluidLayoutRowFacade<TContent> | undefined;
 
 /**
  * Represents a callback to modify the layout row.
@@ -42,24 +34,10 @@ export type FluidLayoutRowsSelector<
  * @param rowFacade - row facade for convenient work with the column
  * @returns row builder with applied transforms
  */
-export type FluidLayoutRowModifications<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TRow extends IFluidLayoutRow<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>,
-    TColumnsFacade extends IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade>,
-    TColumnBuilder extends IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade>,
-    TRowBuilder extends IFluidLayoutRowBuilder<
-        TContent,
-        TRow,
-        TColumn,
-        TRowFacade,
-        TColumnFacade,
-        TColumnsFacade,
-        TColumnBuilder
-    >
-> = (rowBuilder: TRowBuilder, rowFacade: TRowFacade) => TRowBuilder;
+export type FluidLayoutRowModifications<TContent> = (
+    rowBuilder: IFluidLayoutRowBuilder<TContent>,
+    rowFacade: IFluidLayoutRowFacade<TContent>,
+) => IFluidLayoutRowBuilder<TContent>;
 
 /**
  * Represents a query to select a subset of row columns.
@@ -68,12 +46,9 @@ export type FluidLayoutRowModifications<
  * @param columnsFacade - columns facade to create a query
  * @returns array of column facades, single column facade, or undefined
  */
-export type FluidLayoutColumnsSelector<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>,
-    TColumnsFacade extends IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade>
-> = (columnsFacade: TColumnsFacade) => TColumnFacade[] | TColumnFacade | undefined;
+export type FluidLayoutColumnsSelector<TContent> = (
+    columnsFacade: IFluidLayoutColumnsFacade<TContent>,
+) => IFluidLayoutColumnFacade<TContent>[] | IFluidLayoutColumnFacade<TContent> | undefined;
 
 /**
  * Represents a callback to modify the layout column.
@@ -83,12 +58,10 @@ export type FluidLayoutColumnsSelector<
  * @param columnFacade - column facade for convenient work with the column
  * @returns row builder with applied transforms
  */
-export type FluidLayoutColumnModifications<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>,
-    TColumnBuilder extends IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade>
-> = (columnBuilder: TColumnBuilder, columnFacade: TColumnFacade) => TColumnBuilder;
+export type FluidLayoutColumnModifications<TContent> = (
+    columnBuilder: IFluidLayoutColumnBuilder<TContent>,
+    columnFacade: IFluidLayoutColumnFacade<TContent>,
+) => IFluidLayoutColumnBuilder<TContent>;
 
 /**
  * Represents a callback to modify the layout.
@@ -98,40 +71,10 @@ export type FluidLayoutColumnModifications<
  * @param layoutFacade - layout facade for convenient work with the layout
  * @returns layout builder with applied transforms
  */
-export type FluidLayoutModifications<
-    TContent,
-    TLayout extends IFluidLayout<TContent>,
-    TRow extends IFluidLayoutRow<TContent>,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>,
-    TRowsFacade extends IFluidLayoutRowsFacade<TContent, TRow, TRowFacade>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>,
-    TColumnsFacade extends IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade>,
-    TLayoutFacade extends IFluidLayoutFacade<TContent, TLayout>,
-    TColumnBuilder extends IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade>,
-    TRowBuilder extends IFluidLayoutRowBuilder<
-        TContent,
-        TRow,
-        TColumn,
-        TRowFacade,
-        TColumnFacade,
-        TColumnsFacade,
-        TColumnBuilder
-    >,
-    TLayoutBuilder extends IFluidLayoutBuilder<
-        TContent,
-        TLayout,
-        TRow,
-        TColumn,
-        TRowFacade,
-        TRowsFacade,
-        TColumnFacade,
-        TColumnsFacade,
-        TLayoutFacade,
-        TColumnBuilder,
-        TRowBuilder
-    >
-> = (layoutBuilder: TLayoutBuilder, layoutFacade: TLayoutFacade) => TLayoutBuilder;
+export type FluidLayoutModifications<TContent> = (
+    layoutBuilder: IFluidLayoutBuilder<TContent>,
+    layoutFacade: IFluidLayoutFacade<TContent>,
+) => IFluidLayoutBuilder<TContent>;
 
 /**
  * Represents a callback to update the value, or the value itself.
@@ -144,11 +87,7 @@ export type ValueOrUpdateCallback<TValue> = TValue | ((value: TValue) => TValue)
  *
  * @alpha
  */
-export interface IFluidLayoutColumnBuilder<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
-> {
+export interface IFluidLayoutColumnBuilder<TContent> {
     /**
      * Set or update column size.
      *
@@ -172,14 +111,14 @@ export interface IFluidLayoutColumnBuilder<
      * @param valueOrUpdateCallback - raw column data or update callback
      * @returns this
      */
-    setColumn(valueOrUpdateCallback: ValueOrUpdateCallback<TColumn>): this;
+    setColumn(valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutColumn<TContent>>): this;
 
     /**
      * Get facade for the modified column.
      *
      * @returns column facade
      */
-    facade(): TColumnFacade;
+    facade(): IFluidLayoutColumnFacade<TContent>;
 
     /**
      * Perform set of the modifications on the column.
@@ -188,14 +127,14 @@ export interface IFluidLayoutColumnBuilder<
      * @param modifications - callback to modify the column
      * @returns this
      */
-    modify(modifications: FluidLayoutColumnModifications<TContent, TColumn, TColumnFacade, this>): this;
+    modify(modifications: FluidLayoutColumnModifications<TContent>): this;
 
     /**
      * Get raw data of the modified column.
      *
      * @returns raw data of the modified column
      */
-    build(): TColumn;
+    build(): IFluidLayoutColumn<TContent>;
 }
 
 /**
@@ -203,15 +142,7 @@ export interface IFluidLayoutColumnBuilder<
  *
  * @alpha
  */
-export interface IFluidLayoutRowBuilder<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>,
-    TColumnsFacade extends IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade>,
-    TColumnBuilder extends IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade>
-> {
+export interface IFluidLayoutRowBuilder<TContent> {
     /**
      * Set or update row header.
      *
@@ -238,7 +169,7 @@ export interface IFluidLayoutRowBuilder<
      */
     addColumn(
         xlSize: IFluidLayoutSize,
-        create?: (builder: TColumnBuilder) => TColumnBuilder,
+        create?: (builder: IFluidLayoutColumnBuilder<TContent>) => IFluidLayoutColumnBuilder<TContent>,
         index?: number,
     ): this;
 
@@ -254,10 +185,7 @@ export interface IFluidLayoutRowBuilder<
      * @param modify - callback to modify the column
      * @returns this
      */
-    modifyColumn(
-        index: number,
-        modify: FluidLayoutColumnModifications<TContent, TColumn, TColumnFacade, TColumnBuilder>,
-    ): this;
+    modifyColumn(index: number, modify: FluidLayoutColumnModifications<TContent>): this;
 
     /**
      * Remove the column at a specified index.
@@ -303,8 +231,8 @@ export interface IFluidLayoutRowBuilder<
      * @returns this
      */
     modifyColumns(
-        modify: FluidLayoutColumnModifications<TContent, TColumn, TColumnFacade, TColumnBuilder>,
-        selector?: FluidLayoutColumnsSelector<TContent, TColumn, TColumnFacade, TColumnsFacade>,
+        modify: FluidLayoutColumnModifications<TContent>,
+        selector?: FluidLayoutColumnsSelector<TContent>,
     ): this;
 
     /**
@@ -321,9 +249,7 @@ export interface IFluidLayoutRowBuilder<
      * @param selector - query to select the target columns you want to remove
      * @returns this
      */
-    removeColumns(
-        selector?: FluidLayoutColumnsSelector<TContent, TColumn, TColumnFacade, TColumnsFacade>,
-    ): this;
+    removeColumns(selector?: FluidLayoutColumnsSelector<TContent>): this;
 
     /**
      * Remove all empty columns.
@@ -339,14 +265,14 @@ export interface IFluidLayoutRowBuilder<
      * @param valueOrUpdateCallback - raw row data or update callback
      * @returns this
      */
-    setRow(valueOrUpdateCallback: ValueOrUpdateCallback<TRow>): this;
+    setRow(valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayoutRow<TContent>>): this;
 
     /**
      * Get facade for the modified row.
      *
      * @returns row facade
      */
-    facade(): TRowFacade;
+    facade(): IFluidLayoutRowFacade<TContent>;
 
     /**
      * Perform set of the modifications on the row.
@@ -355,25 +281,14 @@ export interface IFluidLayoutRowBuilder<
      * @param modifications - callback to modify the row
      * @returns this
      */
-    modify(
-        modifications: FluidLayoutRowModifications<
-            TContent,
-            TColumn,
-            TRow,
-            TRowFacade,
-            TColumnFacade,
-            TColumnsFacade,
-            TColumnBuilder,
-            this
-        >,
-    ): this;
+    modify(modifications: FluidLayoutRowModifications<TContent>): this;
 
     /**
      * Get raw data of the modified row.
      *
      * @returns raw data of the modified row
      */
-    build(): TRow;
+    build(): IFluidLayoutRow<TContent>;
 }
 
 /**
@@ -382,27 +297,7 @@ export interface IFluidLayoutRowBuilder<
  *
  * @alpha
  */
-export interface IFluidLayoutBuilder<
-    TContent,
-    TLayout extends IFluidLayout<TContent>,
-    TRow extends IFluidLayoutRow<TContent>,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>,
-    TRowsFacade extends IFluidLayoutRowsFacade<TContent, TRow, TRowFacade>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>,
-    TColumnsFacade extends IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade>,
-    TLayoutFacade extends IFluidLayoutFacade<TContent, TLayout>,
-    TColumnBuilder extends IFluidLayoutColumnBuilder<TContent, TColumn, TColumnFacade>,
-    TRowBuilder extends IFluidLayoutRowBuilder<
-        TContent,
-        TRow,
-        TColumn,
-        TRowFacade,
-        TColumnFacade,
-        TColumnsFacade,
-        TColumnBuilder
-    >
-> {
+export interface IFluidLayoutBuilder<TContent> {
     /**
      * Set or update layout size.
      *
@@ -427,7 +322,10 @@ export interface IFluidLayoutBuilder<
      * @param index - index where to place the row
      * @returns this
      */
-    addRow(create?: (builder: TRowBuilder) => TRowBuilder, index?: number): this;
+    addRow(
+        create?: (builder: IFluidLayoutRowBuilder<TContent>) => IFluidLayoutRowBuilder<TContent>,
+        index?: number,
+    ): this;
 
     /**
      * Modify row at a specified index.
@@ -441,19 +339,7 @@ export interface IFluidLayoutBuilder<
      * @param modify - callback to modify the row
      * @returns this
      */
-    modifyRow(
-        index: number,
-        modify: FluidLayoutRowModifications<
-            TContent,
-            TColumn,
-            TRow,
-            TRowFacade,
-            TColumnFacade,
-            TColumnsFacade,
-            TColumnBuilder,
-            TRowBuilder
-        >,
-    ): this;
+    modifyRow(index: number, modify: FluidLayoutRowModifications<TContent>): this;
 
     /**
      * Remove the row at a specified index.
@@ -499,17 +385,8 @@ export interface IFluidLayoutBuilder<
      * @returns this
      */
     modifyRows(
-        modify: FluidLayoutRowModifications<
-            TContent,
-            TColumn,
-            TRow,
-            TRowFacade,
-            TColumnFacade,
-            TColumnsFacade,
-            TColumnBuilder,
-            TRowBuilder
-        >,
-        selector?: FluidLayoutRowsSelector<TContent, TRow, TRowFacade, TRowsFacade>,
+        modify: FluidLayoutRowModifications<TContent>,
+        selector?: FluidLayoutRowsSelector<TContent>,
     ): this;
 
     /**
@@ -526,7 +403,7 @@ export interface IFluidLayoutBuilder<
      * @param selector - query to select the target rows you want to modify
      * @returns this
      */
-    removeRows(selector?: FluidLayoutRowsSelector<TContent, TRow, TRowFacade, TRowsFacade>): this;
+    removeRows(selector?: FluidLayoutRowsSelector<TContent>): this;
 
     /**
      * Remove all empty rows.
@@ -542,14 +419,14 @@ export interface IFluidLayoutBuilder<
      * @param valueOrUpdateCallback - raw layout data or update callback
      * @returns this
      */
-    setLayout(valueOrUpdateCallback: ValueOrUpdateCallback<TLayout>): this;
+    setLayout(valueOrUpdateCallback: ValueOrUpdateCallback<IFluidLayout<TContent>>): this;
 
     /**
      * Get facade for the modified layout.
      *
      * @returns layout facade
      */
-    facade(): TLayoutFacade;
+    facade(): IFluidLayoutFacade<TContent>;
 
     /**
      * Perform set of the modifications on the layout.
@@ -558,66 +435,27 @@ export interface IFluidLayoutBuilder<
      * @param modifications - callback to modify the layout
      * @returns this
      */
-    modify(
-        modifications: FluidLayoutModifications<
-            TContent,
-            TLayout,
-            TRow,
-            TColumn,
-            TRowFacade,
-            TRowsFacade,
-            TColumnFacade,
-            TColumnsFacade,
-            TLayoutFacade,
-            TColumnBuilder,
-            TRowBuilder,
-            this
-        >,
-    ): this;
+    modify(modifications: FluidLayoutModifications<TContent>): this;
 
     /**
      * Get raw data of the modified layout.
      *
      * @returns raw data of the modified layout
      */
-    build(): TLayout;
+    build(): IFluidLayout<TContent>;
 }
 
 /**
  * @alpha
  */
-export type IFluidLayoutBuilderImpl<TContent> = IFluidLayoutBuilder<
-    TContent,
-    IFluidLayout<TContent>,
-    IFluidLayoutRow<TContent>,
-    IFluidLayoutColumn<TContent>,
-    IFluidLayoutRowFacadeImpl<TContent>,
-    IFluidLayoutRowsFacadeImpl<TContent>,
-    IFluidLayoutColumnFacadeImpl<TContent>,
-    IFluidLayoutColumnsFacadeImpl<TContent>,
-    IFluidLayoutFacadeImpl<TContent>,
-    IFluidLayoutColumnBuilderImpl<TContent>,
-    IFluidLayoutRowBuilderImpl<TContent>
->;
+export type IFluidLayoutBuilderImpl<TContent> = IFluidLayoutBuilder<TContent>;
 
 /**
  * @alpha
  */
-export type IFluidLayoutRowBuilderImpl<TContent> = IFluidLayoutRowBuilder<
-    TContent,
-    IFluidLayoutRow<TContent>,
-    IFluidLayoutColumn<TContent>,
-    IFluidLayoutRowFacadeImpl<TContent>,
-    IFluidLayoutColumnFacadeImpl<TContent>,
-    IFluidLayoutColumnsFacadeImpl<TContent>,
-    IFluidLayoutColumnBuilderImpl<TContent>
->;
+export type IFluidLayoutRowBuilderImpl<TContent> = IFluidLayoutRowBuilder<TContent>;
 
 /**
  * @alpha
  */
-export type IFluidLayoutColumnBuilderImpl<TContent> = IFluidLayoutColumnBuilder<
-    TContent,
-    IFluidLayoutColumn<TContent>,
-    IFluidLayoutColumnFacadeImpl<TContent>
->;
+export type IFluidLayoutColumnBuilderImpl<TContent> = IFluidLayoutColumnBuilder<TContent>;

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/interfaces.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/interfaces.ts
@@ -444,18 +444,3 @@ export interface IFluidLayoutBuilder<TContent> {
      */
     build(): IFluidLayout<TContent>;
 }
-
-/**
- * @alpha
- */
-export type IFluidLayoutBuilderImpl<TContent> = IFluidLayoutBuilder<TContent>;
-
-/**
- * @alpha
- */
-export type IFluidLayoutRowBuilderImpl<TContent> = IFluidLayoutRowBuilder<TContent>;
-
-/**
- * @alpha
- */
-export type IFluidLayoutColumnBuilderImpl<TContent> = IFluidLayoutColumnBuilder<TContent>;

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/layout.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/layout.ts
@@ -12,9 +12,7 @@ import {
     FluidLayoutRowModifications,
     FluidLayoutRowsSelector,
     IFluidLayoutBuilder,
-    IFluidLayoutBuilderImpl,
     IFluidLayoutRowBuilder,
-    IFluidLayoutRowBuilderImpl,
     ValueOrUpdateCallback,
 } from "./interfaces";
 import { FluidLayoutRowBuilder } from "./row";
@@ -35,15 +33,15 @@ export class FluidLayoutBuilder<TContent> implements IFluidLayoutBuilder<TConten
      *
      * @param layout - layout to modify
      */
-    public static for<TContent>(layout: IFluidLayout<TContent>): IFluidLayoutBuilderImpl<TContent> {
+    public static for<TContent>(layout: IFluidLayout<TContent>): IFluidLayoutBuilder<TContent> {
         invariant(isFluidLayout(layout), "Provided data must be IFluidLayout!");
-        const fluidLayoutBuilder: IFluidLayoutBuilderImpl<TContent> = new FluidLayoutBuilder(
+        const fluidLayoutBuilder: IFluidLayoutBuilder<TContent> = new FluidLayoutBuilder(
             FluidLayoutFacade.for(layout),
             FluidLayoutFacade.for,
             getRowBuilder,
         );
 
-        function getRowBuilder(rowIndex: number): IFluidLayoutRowBuilderImpl<TContent> {
+        function getRowBuilder(rowIndex: number): IFluidLayoutRowBuilder<TContent> {
             return FluidLayoutRowBuilder.for(fluidLayoutBuilder, rowIndex);
         }
 
@@ -53,7 +51,7 @@ export class FluidLayoutBuilder<TContent> implements IFluidLayoutBuilder<TConten
     /**
      * Creates an instance of FluidLayoutBuilder with empty layout.
      */
-    public static forNewLayout<TContent>(): IFluidLayoutBuilderImpl<TContent> {
+    public static forNewLayout<TContent>(): IFluidLayoutBuilder<TContent> {
         const emptyFluidLayout: IFluidLayout<TContent> = {
             type: "fluidLayout",
             rows: [],

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/row.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/row.ts
@@ -18,14 +18,12 @@ import {
     FluidLayoutColumnsSelector,
     FluidLayoutRowModifications,
     IFluidLayoutColumnBuilder,
-    IFluidLayoutColumnBuilderImpl,
     IFluidLayoutRowBuilder,
-    IFluidLayoutRowBuilderImpl,
+    IFluidLayoutBuilder,
     ValueOrUpdateCallback,
 } from "./interfaces";
 import { FluidLayoutColumnBuilder } from "./column";
 import { resolveValueOrUpdateCallback } from "./utils";
-import { IFluidLayoutBuilderImpl } from "./interfaces";
 
 /**
  * @alpha
@@ -45,15 +43,15 @@ export class FluidLayoutRowBuilder<TContent> implements IFluidLayoutRowBuilder<T
      * @param column - column to modify
      */
     public static for<TContent>(
-        layoutBuilder: IFluidLayoutBuilderImpl<TContent>,
+        layoutBuilder: IFluidLayoutBuilder<TContent>,
         rowIndex: number,
-    ): IFluidLayoutRowBuilderImpl<TContent> {
+    ): IFluidLayoutRowBuilder<TContent> {
         invariant(
             isFluidLayoutRow(layoutBuilder.facade().rows().row(rowIndex)?.raw()),
             "Provided data must be IFluidLayoutRow!",
         );
 
-        const rowBuilder: IFluidLayoutRowBuilderImpl<TContent> = new FluidLayoutRowBuilder(
+        const rowBuilder: IFluidLayoutRowBuilder<TContent> = new FluidLayoutRowBuilder(
             rowIndex,
             layoutBuilder.setLayout,
             () => layoutBuilder.facade().rows().row(rowIndex)!,
@@ -61,7 +59,7 @@ export class FluidLayoutRowBuilder<TContent> implements IFluidLayoutRowBuilder<T
             getColumnBuilder,
         );
 
-        function getColumnBuilder(columnIndex: number): IFluidLayoutColumnBuilderImpl<TContent> {
+        function getColumnBuilder(columnIndex: number): IFluidLayoutColumnBuilder<TContent> {
             return FluidLayoutColumnBuilder.for<TContent>(rowBuilder, columnIndex);
         }
 

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/tests/utils.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/builder/tests/utils.ts
@@ -1,8 +1,8 @@
 // (C) 2019-2021 GoodData Corporation
 import {
-    IFluidLayoutBuilderImpl,
-    IFluidLayoutColumnBuilderImpl,
-    IFluidLayoutRowBuilderImpl,
+    IFluidLayoutBuilder,
+    IFluidLayoutColumnBuilder,
+    IFluidLayoutRowBuilder,
     ValueOrUpdateCallback,
 } from "../interfaces";
 import { IFluidLayoutSize } from "../../fluidLayout";
@@ -21,11 +21,11 @@ export const createValueOrUpdateCallbackTestCases = <TValue>(
     ["by callback returning undefined", () => undefined],
 ];
 
-export const createEmptyFluidLayoutBuilder = (): IFluidLayoutBuilderImpl<any> =>
+export const createEmptyFluidLayoutBuilder = (): IFluidLayoutBuilder<any> =>
     FluidLayoutBuilder.forNewLayout();
 
-export const createEmptyFluidLayoutRowBuilder = (): IFluidLayoutRowBuilderImpl<any> =>
+export const createEmptyFluidLayoutRowBuilder = (): IFluidLayoutRowBuilder<any> =>
     FluidLayoutRowBuilder.for(createEmptyFluidLayoutBuilder().addRow(), 0);
 
-export const createEmptyFluidLayoutColumnBuilder = (): IFluidLayoutColumnBuilderImpl<any> =>
+export const createEmptyFluidLayoutColumnBuilder = (): IFluidLayoutColumnBuilder<any> =>
     FluidLayoutColumnBuilder.for(createEmptyFluidLayoutRowBuilder().addColumn(defaultColumnXlSize), 0);

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/column.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/column.ts
@@ -3,7 +3,6 @@ import isEqual from "lodash/isEqual";
 import isNil from "lodash/isNil";
 import {
     IFluidLayoutColumn,
-    IFluidLayoutRow,
     IFluidLayoutSize,
     IFluidLayoutSizeByScreen,
     ResponsiveScreenType,
@@ -19,15 +18,10 @@ import {
 /**
  * @alpha
  */
-export class FluidLayoutColumnFacade<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TRow extends IFluidLayoutRow<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>
-> implements IFluidLayoutColumnFacade<TContent, TColumn> {
+export class FluidLayoutColumnFacade<TContent> implements IFluidLayoutColumnFacade<TContent> {
     protected constructor(
-        protected readonly rowFacade: TRowFacade,
-        protected readonly column: TColumn,
+        protected readonly rowFacade: IFluidLayoutRowFacade<TContent>,
+        protected readonly column: IFluidLayoutColumn<TContent>,
         protected readonly columnIndex: number,
     ) {}
 
@@ -39,7 +33,7 @@ export class FluidLayoutColumnFacade<
         return new FluidLayoutColumnFacade(rowFacade, column, index);
     }
 
-    public raw(): TColumn {
+    public raw(): IFluidLayoutColumn<TContent> {
         return this.column;
     }
 
@@ -87,7 +81,7 @@ export class FluidLayoutColumnFacade<
         return this.indexIs(this.rowFacade.columns().count() - 1);
     }
 
-    public testRaw(pred: (column: TColumn) => boolean): boolean {
+    public testRaw(pred: (column: IFluidLayoutColumn<TContent>) => boolean): boolean {
         return pred(this.raw());
     }
 

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/column.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/column.ts
@@ -8,12 +8,7 @@ import {
     ResponsiveScreenType,
 } from "../fluidLayout";
 
-import {
-    IFluidLayoutColumnFacade,
-    IFluidLayoutColumnFacadeImpl,
-    IFluidLayoutRowFacade,
-    IFluidLayoutRowFacadeImpl,
-} from "./interfaces";
+import { IFluidLayoutColumnFacade, IFluidLayoutRowFacade } from "./interfaces";
 
 /**
  * @alpha
@@ -26,10 +21,10 @@ export class FluidLayoutColumnFacade<TContent> implements IFluidLayoutColumnFaca
     ) {}
 
     public static for<TContent>(
-        rowFacade: IFluidLayoutRowFacadeImpl<TContent>,
+        rowFacade: IFluidLayoutRowFacade<TContent>,
         column: IFluidLayoutColumn<TContent>,
         index: number,
-    ): IFluidLayoutColumnFacadeImpl<TContent> {
+    ): IFluidLayoutColumnFacade<TContent> {
         return new FluidLayoutColumnFacade(rowFacade, column, index);
     }
 
@@ -93,7 +88,7 @@ export class FluidLayoutColumnFacade<TContent> implements IFluidLayoutColumnFaca
         return isNil(this.content);
     }
 
-    public row(): IFluidLayoutRowFacadeImpl<TContent> {
+    public row(): IFluidLayoutRowFacade<TContent> {
         return this.rowFacade;
     }
 }

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/columns.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/columns.ts
@@ -12,12 +12,8 @@ import { FluidLayoutColumnFacade } from "./column";
 /**
  * @alpha
  */
-export class FluidLayoutColumnsFacade<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
-> implements IFluidLayoutColumnsFacade<TContent, TColumn, TColumnFacade> {
-    protected constructor(protected readonly columnFacades: TColumnFacade[]) {}
+export class FluidLayoutColumnsFacade<TContent> implements IFluidLayoutColumnsFacade<TContent> {
+    protected constructor(protected readonly columnFacades: IFluidLayoutColumnFacade<TContent>[]) {}
 
     public static for<TContent>(
         rowFacade: IFluidLayoutRowFacadeImpl<TContent>,
@@ -29,46 +25,50 @@ export class FluidLayoutColumnsFacade<
         return new FluidLayoutColumnsFacade(columnFacades);
     }
 
-    public raw(): TColumn[] {
+    public raw(): IFluidLayoutColumn<TContent>[] {
         return this.columnFacades.map((columnFacade) => columnFacade.raw());
     }
 
-    public column(columnIndex: number): TColumnFacade | undefined {
+    public column(columnIndex: number): IFluidLayoutColumnFacade<TContent> | undefined {
         return this.columnFacades[columnIndex];
     }
 
-    public map<TReturn>(callback: (column: TColumnFacade) => TReturn): TReturn[] {
+    public map<TReturn>(callback: (column: IFluidLayoutColumnFacade<TContent>) => TReturn): TReturn[] {
         return this.columnFacades.map(callback);
     }
 
-    public flatMap<TReturn>(callback: (column: TColumnFacade) => TReturn[]): TReturn[] {
+    public flatMap<TReturn>(callback: (column: IFluidLayoutColumnFacade<TContent>) => TReturn[]): TReturn[] {
         return flatMap(this.columnFacades, callback);
     }
 
     public reduce<TReturn>(
-        callback: (acc: TReturn, row: TColumnFacade) => TReturn,
+        callback: (acc: TReturn, row: IFluidLayoutColumnFacade<TContent>) => TReturn,
         initialValue: TReturn,
     ): TReturn {
         return this.columnFacades.reduce(callback, initialValue);
     }
 
-    public find(pred: (row: TColumnFacade) => boolean): TColumnFacade | undefined {
+    public find(
+        pred: (row: IFluidLayoutColumnFacade<TContent>) => boolean,
+    ): IFluidLayoutColumnFacade<TContent> | undefined {
         return this.columnFacades.find(pred);
     }
 
-    public every(pred: (row: TColumnFacade) => boolean): boolean {
+    public every(pred: (row: IFluidLayoutColumnFacade<TContent>) => boolean): boolean {
         return this.columnFacades.every(pred);
     }
 
-    public some(pred: (row: TColumnFacade) => boolean): boolean {
+    public some(pred: (row: IFluidLayoutColumnFacade<TContent>) => boolean): boolean {
         return this.columnFacades.some(pred);
     }
 
-    public filter(pred: (row: TColumnFacade) => boolean): TColumnFacade[] {
+    public filter(
+        pred: (row: IFluidLayoutColumnFacade<TContent>) => boolean,
+    ): IFluidLayoutColumnFacade<TContent>[] {
         return this.columnFacades.filter(pred);
     }
 
-    public all(): TColumnFacade[] {
+    public all(): IFluidLayoutColumnFacade<TContent>[] {
         return this.columnFacades;
     }
 

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/columns.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/columns.ts
@@ -1,12 +1,7 @@
 // (C) 2019-2021 GoodData Corporation
 import flatMap from "lodash/flatMap";
 import { IFluidLayoutColumn } from "../fluidLayout";
-import {
-    IFluidLayoutColumnFacade,
-    IFluidLayoutColumnsFacade,
-    IFluidLayoutColumnsFacadeImpl,
-    IFluidLayoutRowFacadeImpl,
-} from "./interfaces";
+import { IFluidLayoutColumnFacade, IFluidLayoutColumnsFacade, IFluidLayoutRowFacade } from "./interfaces";
 import { FluidLayoutColumnFacade } from "./column";
 
 /**
@@ -16,9 +11,9 @@ export class FluidLayoutColumnsFacade<TContent> implements IFluidLayoutColumnsFa
     protected constructor(protected readonly columnFacades: IFluidLayoutColumnFacade<TContent>[]) {}
 
     public static for<TContent>(
-        rowFacade: IFluidLayoutRowFacadeImpl<TContent>,
+        rowFacade: IFluidLayoutRowFacade<TContent>,
         columns: IFluidLayoutColumn<TContent>[],
-    ): IFluidLayoutColumnsFacadeImpl<TContent> {
+    ): IFluidLayoutColumnsFacade<TContent> {
         const columnFacades = columns.map((column, index) =>
             FluidLayoutColumnFacade.for(rowFacade, column, index),
         );

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/interfaces.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/interfaces.ts
@@ -122,28 +122,3 @@ export interface IFluidLayoutFacade<TContent> {
     rows(): IFluidLayoutRowsFacade<TContent>;
     raw(): IFluidLayout<TContent>;
 }
-
-/**
- * @alpha
- */
-export type IFluidLayoutFacadeImpl<TContent> = IFluidLayoutFacade<TContent>;
-
-/**
- * @alpha
- */
-export type IFluidLayoutRowsFacadeImpl<TContent> = IFluidLayoutRowsFacade<TContent>;
-
-/**
- * @alpha
- */
-export type IFluidLayoutRowFacadeImpl<TContent> = IFluidLayoutRowFacade<TContent>;
-
-/**
- * @alpha
- */
-export type IFluidLayoutColumnsFacadeImpl<TContent> = IFluidLayoutColumnsFacade<TContent>;
-
-/**
- * @alpha
- */
-export type IFluidLayoutColumnFacadeImpl<TContent> = IFluidLayoutColumnFacade<TContent>;

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/interfaces.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/interfaces.ts
@@ -12,10 +12,10 @@ import {
 /**
  * @alpha
  */
-export interface IFluidLayoutColumnFacade<TContent, TColumn extends IFluidLayoutColumn<TContent>> {
-    raw(): TColumn;
+export interface IFluidLayoutColumnFacade<TContent> {
+    raw(): IFluidLayoutColumn<TContent>;
 
-    testRaw(pred: (column: TColumn) => boolean): boolean;
+    testRaw(pred: (column: IFluidLayoutColumn<TContent>) => boolean): boolean;
     test(pred: (column: this) => boolean): boolean;
 
     index(): number;
@@ -36,40 +36,38 @@ export interface IFluidLayoutColumnFacade<TContent, TColumn extends IFluidLayout
     isEmpty(): boolean;
 
     // override
-    row(): IFluidLayoutRowFacade<TContent, IFluidLayoutRow<TContent>>;
+    row(): IFluidLayoutRowFacade<TContent>;
 }
 
 /**
  * @alpha
  */
-export interface IFluidLayoutColumnsFacade<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
-> {
-    raw(): TColumn[];
-    column(columnIndex: number): TColumnFacade | undefined;
-    map<TReturn>(callback: (column: TColumnFacade) => TReturn): TReturn[];
-    flatMap<TReturn>(callback: (row: TColumnFacade) => TReturn[]): TReturn[];
+export interface IFluidLayoutColumnsFacade<TContent> {
+    raw(): IFluidLayoutColumn<TContent>[];
+    column(columnIndex: number): IFluidLayoutColumnFacade<TContent> | undefined;
+    map<TReturn>(callback: (column: IFluidLayoutColumnFacade<TContent>) => TReturn): TReturn[];
+    flatMap<TReturn>(callback: (row: IFluidLayoutColumnFacade<TContent>) => TReturn[]): TReturn[];
     reduce<TReturn>(
-        callback: (acc: TReturn, column: TColumnFacade) => TReturn,
+        callback: (acc: TReturn, column: IFluidLayoutColumnFacade<TContent>) => TReturn,
         initialValue: TReturn,
     ): TReturn;
-    find(pred: (column: TColumnFacade) => boolean): TColumnFacade | undefined;
-    every(pred: (column: TColumnFacade) => boolean): boolean;
-    some(pred: (column: TColumnFacade) => boolean): boolean;
-    filter(pred: (row: TColumnFacade) => boolean): TColumnFacade[];
-    all(): TColumnFacade[];
+    find(
+        pred: (column: IFluidLayoutColumnFacade<TContent>) => boolean,
+    ): IFluidLayoutColumnFacade<TContent> | undefined;
+    every(pred: (column: IFluidLayoutColumnFacade<TContent>) => boolean): boolean;
+    some(pred: (column: IFluidLayoutColumnFacade<TContent>) => boolean): boolean;
+    filter(pred: (row: IFluidLayoutColumnFacade<TContent>) => boolean): IFluidLayoutColumnFacade<TContent>[];
+    all(): IFluidLayoutColumnFacade<TContent>[];
     count(): number;
 }
 
 /**
  * @alpha
  */
-export interface IFluidLayoutRowFacade<TContent, TRow extends IFluidLayoutRow<TContent>> {
-    raw(): TRow;
+export interface IFluidLayoutRowFacade<TContent> {
+    raw(): IFluidLayoutRow<TContent>;
 
-    testRaw(pred: (column: TRow) => boolean): boolean;
+    testRaw(pred: (column: IFluidLayoutRow<TContent>) => boolean): boolean;
     test(pred: (column: this) => boolean): boolean;
 
     index(): number;
@@ -90,80 +88,62 @@ export interface IFluidLayoutRowFacade<TContent, TRow extends IFluidLayoutRow<TC
     isEmpty(): boolean;
 
     // overrides
-    columns(): IFluidLayoutColumnsFacade<
-        TContent,
-        IFluidLayoutColumn<TContent>,
-        IFluidLayoutColumnFacade<TContent, IFluidLayoutColumn<TContent>>
-    >;
-    layout(): IFluidLayoutFacade<TContent, IFluidLayout<TContent>>;
+    columns(): IFluidLayoutColumnsFacade<TContent>;
+    layout(): IFluidLayoutFacade<TContent>;
 }
 
 /**
  * @alpha
  */
-export interface IFluidLayoutRowsFacade<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>
-> {
-    raw(): TRow[];
-    row(rowIndex: number): TRowFacade | undefined;
-    map<TReturn>(callback: (row: TRowFacade) => TReturn): TReturn[];
-    flatMap<TReturn>(callback: (row: TRowFacade) => TReturn[]): TReturn[];
-    reduce<TReturn>(callback: (acc: TReturn, row: TRowFacade) => TReturn, initialValue: TReturn): TReturn;
-    find(pred: (row: TRowFacade) => boolean): TRowFacade | undefined;
-    every(pred: (row: TRowFacade) => boolean): boolean;
-    some(pred: (row: TRowFacade) => boolean): boolean;
-    filter(pred: (row: TRowFacade) => boolean): TRowFacade[];
-    all(): TRowFacade[];
+export interface IFluidLayoutRowsFacade<TContent> {
+    raw(): IFluidLayoutRow<TContent>[];
+    row(rowIndex: number): IFluidLayoutRowFacade<TContent> | undefined;
+    map<TReturn>(callback: (row: IFluidLayoutRowFacade<TContent>) => TReturn): TReturn[];
+    flatMap<TReturn>(callback: (row: IFluidLayoutRowFacade<TContent>) => TReturn[]): TReturn[];
+    reduce<TReturn>(
+        callback: (acc: TReturn, row: IFluidLayoutRowFacade<TContent>) => TReturn,
+        initialValue: TReturn,
+    ): TReturn;
+    find(
+        pred: (row: IFluidLayoutRowFacade<TContent>) => boolean,
+    ): IFluidLayoutRowFacade<TContent> | undefined;
+    every(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): boolean;
+    some(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): boolean;
+    filter(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): IFluidLayoutRowFacade<TContent>[];
+    all(): IFluidLayoutRowFacade<TContent>[];
     count(): number;
 }
 
 /**
  * @alpha
  */
-export interface IFluidLayoutFacade<TContent, TLayout extends IFluidLayout<TContent>> {
+export interface IFluidLayoutFacade<TContent> {
     size(): IFluidLayoutSize | undefined;
-    rows(): IFluidLayoutRowsFacade<
-        TContent,
-        IFluidLayoutRow<TContent>,
-        IFluidLayoutRowFacade<TContent, IFluidLayoutRow<TContent>>
-    >;
-    raw(): TLayout;
+    rows(): IFluidLayoutRowsFacade<TContent>;
+    raw(): IFluidLayout<TContent>;
 }
 
 /**
  * @alpha
  */
-export type IFluidLayoutFacadeImpl<TContent> = IFluidLayoutFacade<TContent, IFluidLayout<TContent>>;
+export type IFluidLayoutFacadeImpl<TContent> = IFluidLayoutFacade<TContent>;
 
 /**
  * @alpha
  */
-export type IFluidLayoutRowsFacadeImpl<TContent> = IFluidLayoutRowsFacade<
-    TContent,
-    IFluidLayoutRow<TContent>,
-    IFluidLayoutRowFacadeImpl<TContent>
->;
+export type IFluidLayoutRowsFacadeImpl<TContent> = IFluidLayoutRowsFacade<TContent>;
 
 /**
  * @alpha
  */
-export type IFluidLayoutRowFacadeImpl<TContent> = IFluidLayoutRowFacade<TContent, IFluidLayoutRow<TContent>>;
+export type IFluidLayoutRowFacadeImpl<TContent> = IFluidLayoutRowFacade<TContent>;
 
 /**
  * @alpha
  */
-export type IFluidLayoutColumnsFacadeImpl<TContent> = IFluidLayoutColumnsFacade<
-    TContent,
-    IFluidLayoutColumn<TContent>,
-    IFluidLayoutColumnFacadeImpl<TContent>
->;
+export type IFluidLayoutColumnsFacadeImpl<TContent> = IFluidLayoutColumnsFacade<TContent>;
 
 /**
  * @alpha
  */
-export type IFluidLayoutColumnFacadeImpl<TContent> = IFluidLayoutColumnFacade<
-    TContent,
-    IFluidLayoutColumn<TContent>
->;
+export type IFluidLayoutColumnFacadeImpl<TContent> = IFluidLayoutColumnFacade<TContent>;

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/layout.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/layout.ts
@@ -2,7 +2,7 @@
 import invariant from "ts-invariant";
 import { IFluidLayout, IFluidLayoutSize, isFluidLayout } from "../fluidLayout";
 
-import { IFluidLayoutFacade, IFluidLayoutFacadeImpl, IFluidLayoutRowsFacadeImpl } from "./interfaces";
+import { IFluidLayoutFacade, IFluidLayoutRowsFacade } from "./interfaces";
 import { FluidLayoutRowsFacade } from "./rows";
 
 /**
@@ -15,12 +15,12 @@ export class FluidLayoutFacade<TContent> implements IFluidLayoutFacade<TContent>
      * Creates an instance of FluidLayoutFacade
      * @param layout - layout to wrap
      */
-    public static for<TContent>(layout: IFluidLayout<TContent>): IFluidLayoutFacadeImpl<TContent> {
+    public static for<TContent>(layout: IFluidLayout<TContent>): IFluidLayoutFacade<TContent> {
         invariant(isFluidLayout(layout), "Provided data must be IFluidLayout!");
         return new FluidLayoutFacade(layout);
     }
 
-    public rows(): IFluidLayoutRowsFacadeImpl<TContent> {
+    public rows(): IFluidLayoutRowsFacade<TContent> {
         return FluidLayoutRowsFacade.for(this, this.layout.rows);
     }
 

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/layout.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/layout.ts
@@ -8,9 +8,8 @@ import { FluidLayoutRowsFacade } from "./rows";
 /**
  * @alpha
  */
-export class FluidLayoutFacade<TContent, TLayout extends IFluidLayout<TContent>>
-    implements IFluidLayoutFacade<TContent, TLayout> {
-    protected constructor(protected layout: TLayout) {}
+export class FluidLayoutFacade<TContent> implements IFluidLayoutFacade<TContent> {
+    protected constructor(protected layout: IFluidLayout<TContent>) {}
 
     /**
      * Creates an instance of FluidLayoutFacade
@@ -29,7 +28,7 @@ export class FluidLayoutFacade<TContent, TLayout extends IFluidLayout<TContent>>
         return this.layout.size;
     }
 
-    public raw(): TLayout {
+    public raw(): IFluidLayout<TContent> {
         return this.layout;
     }
 }

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/row.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/row.ts
@@ -3,13 +3,7 @@ import isEqual from "lodash/isEqual";
 import isNil from "lodash/isNil";
 import { IFluidLayoutRow, IFluidLayoutSectionHeader } from "../fluidLayout";
 import { FluidLayoutColumnsFacade } from "./columns";
-import {
-    IFluidLayoutRowFacade,
-    IFluidLayoutRowFacadeImpl,
-    IFluidLayoutFacade,
-    IFluidLayoutFacadeImpl,
-    IFluidLayoutColumnsFacadeImpl,
-} from "./interfaces";
+import { IFluidLayoutRowFacade, IFluidLayoutFacade, IFluidLayoutColumnsFacade } from "./interfaces";
 
 /**
  * @alpha
@@ -22,10 +16,10 @@ export class FluidLayoutRowFacade<TContent> implements IFluidLayoutRowFacade<TCo
     ) {}
 
     public static for<TContent>(
-        layoutFacade: IFluidLayoutFacadeImpl<TContent>,
+        layoutFacade: IFluidLayoutFacade<TContent>,
         row: IFluidLayoutRow<TContent>,
         index: number,
-    ): IFluidLayoutRowFacadeImpl<TContent> {
+    ): IFluidLayoutRowFacade<TContent> {
         return new FluidLayoutRowFacade(layoutFacade, row, index);
     }
 
@@ -97,11 +91,11 @@ export class FluidLayoutRowFacade<TContent> implements IFluidLayoutRowFacade<TCo
         return this.columns().count() === 0;
     }
 
-    public columns(): IFluidLayoutColumnsFacadeImpl<TContent> {
+    public columns(): IFluidLayoutColumnsFacade<TContent> {
         return FluidLayoutColumnsFacade.for(this, this.row.columns);
     }
 
-    public layout(): IFluidLayoutFacadeImpl<TContent> {
+    public layout(): IFluidLayoutFacade<TContent> {
         return this.layoutFacade;
     }
 }

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/row.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/row.ts
@@ -1,7 +1,7 @@
 // (C) 2019-2021 GoodData Corporation
 import isEqual from "lodash/isEqual";
 import isNil from "lodash/isNil";
-import { IFluidLayout, IFluidLayoutRow, IFluidLayoutSectionHeader } from "../fluidLayout";
+import { IFluidLayoutRow, IFluidLayoutSectionHeader } from "../fluidLayout";
 import { FluidLayoutColumnsFacade } from "./columns";
 import {
     IFluidLayoutRowFacade,
@@ -14,15 +14,10 @@ import {
 /**
  * @alpha
  */
-export class FluidLayoutRowFacade<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TLayout extends IFluidLayout<TContent>,
-    TLayoutFacade extends IFluidLayoutFacade<TContent, TLayout>
-> implements IFluidLayoutRowFacade<TContent, TRow> {
+export class FluidLayoutRowFacade<TContent> implements IFluidLayoutRowFacade<TContent> {
     protected constructor(
-        protected readonly layoutFacade: TLayoutFacade,
-        protected readonly row: TRow,
+        protected readonly layoutFacade: IFluidLayoutFacade<TContent>,
+        protected readonly row: IFluidLayoutRow<TContent>,
         protected readonly rowIndex: number,
     ) {}
 
@@ -34,7 +29,7 @@ export class FluidLayoutRowFacade<
         return new FluidLayoutRowFacade(layoutFacade, row, index);
     }
 
-    public raw(): TRow {
+    public raw(): IFluidLayoutRow<TContent> {
         return this.row;
     }
 
@@ -62,7 +57,7 @@ export class FluidLayoutRowFacade<
         return this.indexIs(this.layoutFacade.rows().count() - 1);
     }
 
-    public testRaw(pred: (row: TRow) => boolean): boolean {
+    public testRaw(pred: (row: IFluidLayoutRow<TContent>) => boolean): boolean {
         return pred(this.raw());
     }
 

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/rows.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/rows.ts
@@ -1,13 +1,7 @@
 // (C) 2019-2021 GoodData Corporation
 import flatMap from "lodash/flatMap";
 import { IFluidLayoutRow } from "../fluidLayout";
-import {
-    IFluidLayoutRowsFacade,
-    IFluidLayoutRowFacade,
-    IFluidLayoutRowsFacadeImpl,
-    IFluidLayoutFacadeImpl,
-    IFluidLayoutFacade,
-} from "./interfaces";
+import { IFluidLayoutRowsFacade, IFluidLayoutRowFacade, IFluidLayoutFacade } from "./interfaces";
 import { FluidLayoutRowFacade } from "./row";
 
 /**
@@ -20,9 +14,9 @@ export class FluidLayoutRowsFacade<TContent> implements IFluidLayoutRowsFacade<T
     ) {}
 
     public static for<TContent>(
-        layoutFacade: IFluidLayoutFacadeImpl<TContent>,
+        layoutFacade: IFluidLayoutFacade<TContent>,
         rows: IFluidLayoutRow<TContent>[],
-    ): IFluidLayoutRowsFacadeImpl<TContent> {
+    ): IFluidLayoutRowsFacade<TContent> {
         const rowFacades = rows.map((row, index) => FluidLayoutRowFacade.for(layoutFacade, row, index));
         return new FluidLayoutRowsFacade(layoutFacade, rowFacades);
     }

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/rows.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/rows.ts
@@ -1,6 +1,6 @@
 // (C) 2019-2021 GoodData Corporation
 import flatMap from "lodash/flatMap";
-import { IFluidLayout, IFluidLayoutRow } from "../fluidLayout";
+import { IFluidLayoutRow } from "../fluidLayout";
 import {
     IFluidLayoutRowsFacade,
     IFluidLayoutRowFacade,
@@ -13,16 +13,10 @@ import { FluidLayoutRowFacade } from "./row";
 /**
  * @alpha
  */
-export class FluidLayoutRowsFacade<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>,
-    TLayout extends IFluidLayout<TContent>,
-    TLayoutFacade extends IFluidLayoutFacade<TContent, TLayout>
-> implements IFluidLayoutRowsFacade<TContent, TRow, TRowFacade> {
+export class FluidLayoutRowsFacade<TContent> implements IFluidLayoutRowsFacade<TContent> {
     protected constructor(
-        protected readonly layoutFacade: TLayoutFacade,
-        protected readonly rowFacades: TRowFacade[],
+        protected readonly layoutFacade: IFluidLayoutFacade<TContent>,
+        protected readonly rowFacades: IFluidLayoutRowFacade<TContent>[],
     ) {}
 
     public static for<TContent>(
@@ -33,46 +27,50 @@ export class FluidLayoutRowsFacade<
         return new FluidLayoutRowsFacade(layoutFacade, rowFacades);
     }
 
-    public raw(): TRow[] {
+    public raw(): IFluidLayoutRow<TContent>[] {
         return this.rowFacades.map((row) => row.raw());
     }
 
-    public row(rowIndex: number): TRowFacade | undefined {
+    public row(rowIndex: number): IFluidLayoutRowFacade<TContent> | undefined {
         return this.rowFacades[rowIndex];
     }
 
-    public map<TReturn>(callback: (row: TRowFacade) => TReturn): TReturn[] {
+    public map<TReturn>(callback: (row: IFluidLayoutRowFacade<TContent>) => TReturn): TReturn[] {
         return this.rowFacades.map(callback);
     }
 
-    public flatMap<TReturn>(callback: (row: TRowFacade) => TReturn[]): TReturn[] {
+    public flatMap<TReturn>(callback: (row: IFluidLayoutRowFacade<TContent>) => TReturn[]): TReturn[] {
         return flatMap(this.rowFacades, callback);
     }
 
     public reduce<TReturn>(
-        callback: (acc: TReturn, row: TRowFacade) => TReturn,
+        callback: (acc: TReturn, row: IFluidLayoutRowFacade<TContent>) => TReturn,
         initialValue: TReturn,
     ): TReturn {
         return this.rowFacades.reduce(callback, initialValue);
     }
 
-    public find(pred: (row: TRowFacade) => boolean): TRowFacade | undefined {
+    public find(
+        pred: (row: IFluidLayoutRowFacade<TContent>) => boolean,
+    ): IFluidLayoutRowFacade<TContent> | undefined {
         return this.rowFacades.find(pred);
     }
 
-    public every(pred: (row: TRowFacade) => boolean): boolean {
+    public every(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): boolean {
         return this.rowFacades.every(pred);
     }
 
-    public some(pred: (row: TRowFacade) => boolean): boolean {
+    public some(pred: (row: IFluidLayoutRowFacade<TContent>) => boolean): boolean {
         return this.rowFacades.some(pred);
     }
 
-    public filter(pred: (row: TRowFacade) => boolean): TRowFacade[] {
+    public filter(
+        pred: (row: IFluidLayoutRowFacade<TContent>) => boolean,
+    ): IFluidLayoutRowFacade<TContent>[] {
         return this.rowFacades.filter(pred);
     }
 
-    public all(): TRowFacade[] {
+    public all(): IFluidLayoutRowFacade<TContent>[] {
         return this.rowFacades;
     }
 

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/builder/column.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/builder/column.ts
@@ -7,32 +7,23 @@ import {
     isKpiWidget,
     isInsightWidget,
     isInsightWidgetDefinition,
+    IFluidLayoutColumnFacade,
 } from "@gooddata/sdk-backend-spi";
 import { ObjRef } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
-import { IDashboardViewLayoutColumnFacade } from "../facade/interfaces";
-import {
-    IDashboardViewLayoutRow,
-    IDashboardViewLayoutColumn,
-    IDashboardViewLayoutContent,
-} from "../interfaces/dashboardLayout";
+import { IDashboardViewLayoutRow, IDashboardViewLayoutContent } from "../interfaces/dashboardLayout";
 import { IDashboardViewLayoutColumnBuilder, IDashboardViewLayoutRowBuilder } from "./interfaces";
 import { InsightWidgetBuilder, KpiWidgetBuilder } from "@gooddata/sdk-backend-base";
 import identity from "lodash/identity";
 
 export class DashboardViewLayoutColumnBuilder<TContent extends IDashboardViewLayoutContent<any>>
-    extends FluidLayoutColumnBuilder<
-        TContent,
-        IDashboardViewLayoutColumn<TContent>,
-        IDashboardViewLayoutRow<TContent>,
-        IDashboardViewLayoutColumnFacade<TContent>
-    >
+    extends FluidLayoutColumnBuilder<TContent>
     implements IDashboardViewLayoutColumnBuilder<TContent> {
     protected constructor(
         protected setRow: (
             valueOrUpdateCallback: ValueOrUpdateCallback<IDashboardViewLayoutRow<TContent>>,
         ) => void,
-        protected getColumnFacade: () => IDashboardViewLayoutColumnFacade<TContent>,
+        protected getColumnFacade: () => IFluidLayoutColumnFacade<TContent>,
         protected columnIndex: number,
     ) {
         super(setRow, getColumnFacade, columnIndex);

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/builder/interfaces.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/builder/interfaces.ts
@@ -10,18 +10,6 @@ import {
     FluidLayoutColumnModifications,
 } from "@gooddata/sdk-backend-spi";
 import { ObjRef } from "@gooddata/sdk-model";
-import {
-    IDashboardViewLayout,
-    IDashboardViewLayoutColumn,
-    IDashboardViewLayoutRow,
-} from "../interfaces/dashboardLayout";
-import {
-    IDashboardViewLayoutColumnFacade,
-    IDashboardViewLayoutColumnsFacade,
-    IDashboardViewLayoutFacade,
-    IDashboardViewLayoutRowFacade,
-    IDashboardViewLayoutRowsFacade,
-} from "../facade/interfaces";
 import { KpiWidgetBuilder, InsightWidgetBuilder } from "@gooddata/sdk-backend-base";
 
 /**
@@ -29,83 +17,41 @@ import { KpiWidgetBuilder, InsightWidgetBuilder } from "@gooddata/sdk-backend-ba
  *
  * @alpha
  */
-export type DashboardViewLayoutRowsSelector<TContent> = FluidLayoutRowsSelector<
-    TContent,
-    IDashboardViewLayoutRow<TContent>,
-    IDashboardViewLayoutRowFacade<TContent>,
-    IDashboardViewLayoutRowsFacade<TContent>
->;
+export type DashboardViewLayoutRowsSelector<TContent> = FluidLayoutRowsSelector<TContent>;
 
 /**
  * Represents a query to select a subset of row columns.
  *
  * @alpha
  */
-export type DashboardViewLayoutColumnsSelector<TContent> = FluidLayoutColumnsSelector<
-    TContent,
-    IDashboardViewLayoutColumn<TContent>,
-    IDashboardViewLayoutColumnFacade<TContent>,
-    IDashboardViewLayoutColumnsFacade<TContent>
->;
+export type DashboardViewLayoutColumnsSelector<TContent> = FluidLayoutColumnsSelector<TContent>;
 
 /**
  * Represents a callback to modify the layout.
  *
  * @alpha
  */
-export type DashboardViewLayoutModifications<TContent> = FluidLayoutModifications<
-    TContent,
-    IDashboardViewLayout<TContent>,
-    IDashboardViewLayoutRow<TContent>,
-    IDashboardViewLayoutColumn<TContent>,
-    IDashboardViewLayoutRowFacade<TContent>,
-    IDashboardViewLayoutRowsFacade<TContent>,
-    IDashboardViewLayoutColumnFacade<TContent>,
-    IDashboardViewLayoutColumnsFacade<TContent>,
-    IDashboardViewLayoutFacade<TContent>,
-    IDashboardViewLayoutColumnBuilder<TContent>,
-    IDashboardViewLayoutRowBuilder<TContent>,
-    IDashboardViewLayoutBuilder<TContent>
->;
+export type DashboardViewLayoutModifications<TContent> = FluidLayoutModifications<TContent>;
 
 /**
  * Represents a callback to modify the layout row.
  *
  * @alpha
  */
-export type DashboardViewLayoutRowModifications<TContent> = FluidLayoutRowModifications<
-    TContent,
-    IDashboardViewLayoutColumn<TContent>,
-    IDashboardViewLayoutRow<TContent>,
-    IDashboardViewLayoutRowFacade<TContent>,
-    IDashboardViewLayoutColumnFacade<TContent>,
-    IDashboardViewLayoutColumnsFacade<TContent>,
-    IDashboardViewLayoutColumnBuilder<TContent>,
-    IDashboardViewLayoutRowBuilder<TContent>
->;
+export type DashboardViewLayoutRowModifications<TContent> = FluidLayoutRowModifications<TContent>;
 
 /**
  * Represents a callback to modify the layout column.
  *
  * @alpha
  */
-export type DashboardViewLayoutColumnModifications<TContent> = FluidLayoutColumnModifications<
-    TContent,
-    IDashboardViewLayoutColumn<TContent>,
-    IDashboardViewLayoutColumnFacade<TContent>,
-    IDashboardViewLayoutColumnBuilder<TContent>
->;
+export type DashboardViewLayoutColumnModifications<TContent> = FluidLayoutColumnModifications<TContent>;
 /**
  * Builder for convenient creation or transformation of any {@link IDashboardViewLayoutColumn}.
  *
  * @alpha
  */
-export interface IDashboardViewLayoutColumnBuilder<TContent>
-    extends IFluidLayoutColumnBuilder<
-        TContent,
-        IDashboardViewLayoutColumn<TContent>,
-        IDashboardViewLayoutColumnFacade<TContent>
-    > {
+export interface IDashboardViewLayoutColumnBuilder<TContent> extends IFluidLayoutColumnBuilder<TContent> {
     newInsightWidget(insight: ObjRef, create?: (builder: InsightWidgetBuilder) => InsightWidgetBuilder): this;
     modifyInsightWidget(modify: (builder: InsightWidgetBuilder) => InsightWidgetBuilder): this;
     newKpiWidget(measure: ObjRef, create?: (builder: KpiWidgetBuilder) => KpiWidgetBuilder): this;
@@ -117,15 +63,7 @@ export interface IDashboardViewLayoutColumnBuilder<TContent>
  *
  * @alpha
  */
-export type IDashboardViewLayoutRowBuilder<TContent> = IFluidLayoutRowBuilder<
-    TContent,
-    IDashboardViewLayoutRow<TContent>,
-    IDashboardViewLayoutColumn<TContent>,
-    IDashboardViewLayoutRowFacade<TContent>,
-    IDashboardViewLayoutColumnFacade<TContent>,
-    IDashboardViewLayoutColumnsFacade<TContent>,
-    IDashboardViewLayoutColumnBuilder<TContent>
->;
+export type IDashboardViewLayoutRowBuilder<TContent> = IFluidLayoutRowBuilder<TContent>;
 
 /**
  * Builder for convenient creation or transformation of any {@link IDashboardViewLayout}.
@@ -133,16 +71,4 @@ export type IDashboardViewLayoutRowBuilder<TContent> = IFluidLayoutRowBuilder<
  *
  * @alpha
  */
-export type IDashboardViewLayoutBuilder<TContent> = IFluidLayoutBuilder<
-    TContent,
-    IDashboardViewLayout<TContent>,
-    IDashboardViewLayoutRow<TContent>,
-    IDashboardViewLayoutColumn<TContent>,
-    IDashboardViewLayoutRowFacade<TContent>,
-    IDashboardViewLayoutRowsFacade<TContent>,
-    IDashboardViewLayoutColumnFacade<TContent>,
-    IDashboardViewLayoutColumnsFacade<TContent>,
-    IDashboardViewLayoutFacade<TContent>,
-    IDashboardViewLayoutColumnBuilder<TContent>,
-    IDashboardViewLayoutRowBuilder<TContent>
->;
+export type IDashboardViewLayoutBuilder<TContent> = IFluidLayoutBuilder<TContent>;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/builder/layout.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/builder/layout.ts
@@ -1,43 +1,16 @@
 // (C) 2019-2021 GoodData Corporation
 import invariant from "ts-invariant";
 import { isFluidLayout, FluidLayoutBuilder } from "@gooddata/sdk-backend-spi";
-import {
-    IDashboardViewLayoutColumnFacade,
-    IDashboardViewLayoutColumnsFacade,
-    IDashboardViewLayoutFacade,
-    IDashboardViewLayoutRowFacade,
-    IDashboardViewLayoutRowsFacade,
-} from "../facade/interfaces";
+import { IDashboardViewLayoutFacade } from "../facade/interfaces";
 import { DashboardViewLayoutFacade } from "../facade/layout";
-import {
-    IDashboardViewLayoutBuilder,
-    IDashboardViewLayoutColumnBuilder,
-    IDashboardViewLayoutRowBuilder,
-} from "./interfaces";
+import { IDashboardViewLayoutBuilder, IDashboardViewLayoutRowBuilder } from "./interfaces";
 import { DashboardViewLayoutRowBuilder } from "./row";
-import {
-    IDashboardViewLayout,
-    IDashboardViewLayoutColumn,
-    IDashboardViewLayoutRow,
-} from "../interfaces/dashboardLayout";
+import { IDashboardViewLayout } from "../interfaces/dashboardLayout";
 
 /**
  * @alpha
  */
-export class DashboardViewLayoutBuilder<TContent>
-    extends FluidLayoutBuilder<
-        TContent,
-        IDashboardViewLayout<TContent>,
-        IDashboardViewLayoutRow<TContent>,
-        IDashboardViewLayoutColumn<TContent>,
-        IDashboardViewLayoutRowFacade<TContent>,
-        IDashboardViewLayoutRowsFacade<TContent>,
-        IDashboardViewLayoutColumnFacade<TContent>,
-        IDashboardViewLayoutColumnsFacade<TContent>,
-        IDashboardViewLayoutFacade<TContent>,
-        IDashboardViewLayoutColumnBuilder<TContent>,
-        IDashboardViewLayoutRowBuilder<TContent>
-    >
+export class DashboardViewLayoutBuilder<TContent> extends FluidLayoutBuilder<TContent>
     implements IDashboardViewLayoutBuilder<TContent> {
     protected constructor(
         protected layoutFacade: IDashboardViewLayoutFacade<TContent>,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/builder/row.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/builder/row.ts
@@ -1,16 +1,8 @@
 // (C) 2019-2021 GoodData Corporation
 import invariant from "ts-invariant";
 import { isFluidLayoutRow, FluidLayoutRowBuilder } from "@gooddata/sdk-backend-spi";
-import {
-    IDashboardViewLayoutColumnFacade,
-    IDashboardViewLayoutColumnsFacade,
-    IDashboardViewLayoutRowFacade,
-} from "../facade/interfaces";
-import {
-    IDashboardViewLayout,
-    IDashboardViewLayoutColumn,
-    IDashboardViewLayoutRow,
-} from "../interfaces/dashboardLayout";
+import { IDashboardViewLayoutColumnsFacade, IDashboardViewLayoutRowFacade } from "../facade/interfaces";
+import { IDashboardViewLayout } from "../interfaces/dashboardLayout";
 import {
     IDashboardViewLayoutBuilder,
     IDashboardViewLayoutColumnBuilder,
@@ -18,17 +10,7 @@ import {
 } from "./interfaces";
 import { DashboardViewLayoutColumnBuilder } from "./column";
 
-export class DashboardViewLayoutRowBuilder<TContent>
-    extends FluidLayoutRowBuilder<
-        TContent,
-        IDashboardViewLayoutRow<TContent>,
-        IDashboardViewLayoutColumn<TContent>,
-        IDashboardViewLayout<TContent>,
-        IDashboardViewLayoutRowFacade<TContent>,
-        IDashboardViewLayoutColumnFacade<TContent>,
-        IDashboardViewLayoutColumnsFacade<TContent>,
-        IDashboardViewLayoutColumnBuilder<TContent>
-    >
+export class DashboardViewLayoutRowBuilder<TContent> extends FluidLayoutRowBuilder<TContent>
     implements IDashboardViewLayoutRowBuilder<TContent> {
     protected constructor(
         protected rowIndex: number,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/facade/column.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/facade/column.ts
@@ -19,7 +19,6 @@ import {
     IDashboardViewLayout,
     IDashboardViewLayoutColumn,
     IDashboardViewLayoutContent,
-    IDashboardViewLayoutRow,
 } from "../interfaces/dashboardLayout";
 import { IDashboardViewLayoutColumnFacade, IDashboardViewLayoutRowFacade } from "./interfaces";
 import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
@@ -27,13 +26,7 @@ import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
 /**
  * @alpha
  */
-export class DashboardViewLayoutColumnFacade<TContent>
-    extends FluidLayoutColumnFacade<
-        TContent,
-        IDashboardViewLayoutColumn<TContent>,
-        IDashboardViewLayoutRow<TContent>,
-        IDashboardViewLayoutRowFacade<TContent>
-    >
+export class DashboardViewLayoutColumnFacade<TContent> extends FluidLayoutColumnFacade<TContent>
     implements IDashboardViewLayoutColumnFacade<TContent> {
     private constructor(
         protected readonly rowFacade: IDashboardViewLayoutRowFacade<TContent>,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/facade/columns.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/facade/columns.ts
@@ -11,12 +11,7 @@ import { FluidLayoutColumnsFacade } from "@gooddata/sdk-backend-spi";
 /**
  * @alpha
  */
-export class DashboardViewLayoutColumnsFacade<TContent>
-    extends FluidLayoutColumnsFacade<
-        TContent,
-        IDashboardViewLayoutColumn<TContent>,
-        IDashboardViewLayoutColumnFacade<TContent>
-    >
+export class DashboardViewLayoutColumnsFacade<TContent> extends FluidLayoutColumnsFacade<TContent>
     implements IDashboardViewLayoutColumnsFacade<TContent> {
     protected constructor(protected readonly columnFacades: IDashboardViewLayoutColumnFacade<TContent>[]) {
         super(columnFacades);

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/facade/interfaces.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/facade/interfaces.ts
@@ -14,18 +14,12 @@ import {
     IFluidLayoutRowFacade,
 } from "@gooddata/sdk-backend-spi";
 import { ObjRef } from "@gooddata/sdk-model";
-import {
-    IDashboardViewLayout,
-    IDashboardViewLayoutRow,
-    IDashboardViewLayoutColumn,
-    IDashboardViewLayoutContent,
-} from "../interfaces/dashboardLayout";
+import { IDashboardViewLayout, IDashboardViewLayoutContent } from "../interfaces/dashboardLayout";
 
 /**
  * @alpha
  */
-export interface IDashboardViewLayoutColumnFacade<TContent>
-    extends IFluidLayoutColumnFacade<TContent, IDashboardViewLayoutColumn<TContent>> {
+export interface IDashboardViewLayoutColumnFacade<TContent> extends IFluidLayoutColumnFacade<TContent> {
     hasWidgetContent(): this is IDashboardViewLayoutColumnFacade<IWidget>;
     hasWidgetDefinitionContent(): this is IDashboardViewLayoutColumnFacade<IWidgetDefinition>;
     hasKpiWidgetContent(): this is IDashboardViewLayoutColumnFacade<IKpiWidget>;
@@ -47,17 +41,12 @@ export interface IDashboardViewLayoutColumnFacade<TContent>
 /**
  * @alpha
  */
-export type IDashboardViewLayoutColumnsFacade<TContent> = IFluidLayoutColumnsFacade<
-    TContent,
-    IDashboardViewLayoutColumn<TContent>,
-    IDashboardViewLayoutColumnFacade<TContent>
->;
+export type IDashboardViewLayoutColumnsFacade<TContent> = IFluidLayoutColumnsFacade<TContent>;
 
 /**
  * @alpha
  */
-export interface IDashboardViewLayoutRowFacade<TContent>
-    extends IFluidLayoutRowFacade<TContent, IDashboardViewLayoutRow<TContent>> {
+export interface IDashboardViewLayoutRowFacade<TContent> extends IFluidLayoutRowFacade<TContent> {
     // overrides
     columns(): IDashboardViewLayoutColumnsFacade<TContent>;
     layout(): IDashboardViewLayoutFacade<TContent>;
@@ -66,17 +55,12 @@ export interface IDashboardViewLayoutRowFacade<TContent>
 /**
  * @alpha
  */
-export type IDashboardViewLayoutRowsFacade<TContent> = IFluidLayoutRowsFacade<
-    TContent,
-    IDashboardViewLayoutRow<TContent>,
-    IDashboardViewLayoutRowFacade<TContent>
->;
+export type IDashboardViewLayoutRowsFacade<TContent> = IFluidLayoutRowsFacade<TContent>;
 
 /**
  * @alpha
  */
-export interface IDashboardViewLayoutFacade<TContent>
-    extends IFluidLayoutFacade<TContent, IDashboardViewLayout<TContent>> {
+export interface IDashboardViewLayoutFacade<TContent> extends IFluidLayoutFacade<TContent> {
     // overrides
     rows(): IDashboardViewLayoutRowsFacade<TContent>;
 }

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/facade/layout.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/facade/layout.ts
@@ -9,8 +9,7 @@ import { DashboardViewLayoutRowsFacade } from "./rows";
  * TODO: RAIL-2869 add docs
  * @alpha
  */
-export class DashboardViewLayoutFacade<TContent>
-    extends FluidLayoutFacade<TContent, IDashboardViewLayout<TContent>>
+export class DashboardViewLayoutFacade<TContent> extends FluidLayoutFacade<TContent>
     implements IDashboardViewLayoutFacade<TContent> {
     protected constructor(protected readonly layout: IDashboardViewLayout<TContent>) {
         super(layout);

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/facade/row.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/facade/row.ts
@@ -5,19 +5,13 @@ import {
     IDashboardViewLayoutRowFacade,
     IDashboardViewLayoutFacade,
 } from "./interfaces";
-import { IDashboardViewLayout, IDashboardViewLayoutRow } from "../interfaces/dashboardLayout";
+import { IDashboardViewLayoutRow } from "../interfaces/dashboardLayout";
 import { DashboardViewLayoutColumnsFacade } from "./columns";
 
 /**
  * @alpha
  */
-export class DashboardViewLayoutRowFacade<TContent>
-    extends FluidLayoutRowFacade<
-        TContent,
-        IDashboardViewLayoutRow<TContent>,
-        IDashboardViewLayout<TContent>,
-        IDashboardViewLayoutFacade<TContent>
-    >
+export class DashboardViewLayoutRowFacade<TContent> extends FluidLayoutRowFacade<TContent>
     implements IDashboardViewLayoutRowFacade<TContent> {
     protected constructor(
         protected readonly layoutFacade: IDashboardViewLayoutFacade<TContent>,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/facade/rows.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/facade/rows.ts
@@ -1,6 +1,6 @@
 // (C) 2019-2021 GoodData Corporation
 import { FluidLayoutRowsFacade } from "@gooddata/sdk-backend-spi";
-import { IDashboardViewLayout, IDashboardViewLayoutRow } from "../interfaces/dashboardLayout";
+import { IDashboardViewLayoutRow } from "../interfaces/dashboardLayout";
 import {
     IDashboardViewLayoutRowsFacade,
     IDashboardViewLayoutFacade,
@@ -11,14 +11,7 @@ import { DashboardViewLayoutRowFacade } from "./row";
 /**
  * @alpha
  */
-export class DashboardViewLayoutRowsFacade<TContent>
-    extends FluidLayoutRowsFacade<
-        TContent,
-        IDashboardViewLayoutRow<TContent>,
-        IDashboardViewLayoutRowFacade<TContent>,
-        IDashboardViewLayout<TContent>,
-        IDashboardViewLayoutFacade<TContent>
-    >
+export class DashboardViewLayoutRowsFacade<TContent> extends FluidLayoutRowsFacade<TContent>
     implements IDashboardViewLayoutRowsFacade<TContent> {
     protected constructor(
         protected readonly layoutFacade: IDashboardViewLayoutFacade<TContent>,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/interfaces/dashboardLayoutComponents.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/interfaces/dashboardLayoutComponents.ts
@@ -13,18 +13,8 @@ import {
     IFluidLayoutRowHeaderRenderProps,
     IFluidLayoutRowHeaderRenderer,
 } from "../../FluidLayout";
-import {
-    IDashboardViewLayoutColumnFacade,
-    IDashboardViewLayoutFacade,
-    IDashboardViewLayoutRowFacade,
-} from "../facade/interfaces";
 
-import {
-    IDashboardViewLayout,
-    IDashboardViewLayoutColumn,
-    IDashboardViewLayoutContent,
-    IDashboardViewLayoutRow,
-} from "./dashboardLayout";
+import { IDashboardViewLayoutContent } from "./dashboardLayout";
 
 /**
  * @alpha
@@ -38,46 +28,28 @@ export interface IDashboardViewLayoutCommonRenderProps {
  */
 export type IDashboardViewLayoutRowKeyGetter<
     TCustomContent extends IDashboardViewLayoutContent<any>
-> = IFluidLayoutRowKeyGetter<
-    TCustomContent,
-    IDashboardViewLayoutRow<TCustomContent>,
-    IDashboardViewLayoutRowFacade<TCustomContent>
->;
+> = IFluidLayoutRowKeyGetter<TCustomContent>;
 
 /**
  * @alpha
  */
 export type IDashboardViewLayoutRowRenderProps<
     TCustomContent extends IDashboardViewLayoutContent<any>
-> = IFluidLayoutRowRenderProps<
-    TCustomContent,
-    IDashboardViewLayoutRow<TCustomContent>,
-    IDashboardViewLayoutRowFacade<TCustomContent>
-> &
-    IDashboardViewLayoutCommonRenderProps;
+> = IFluidLayoutRowRenderProps<TCustomContent> & IDashboardViewLayoutCommonRenderProps;
 
 /**
  * @alpha
  */
 export type IDashboardViewLayoutRowRenderer<
     TCustomContent extends IDashboardViewLayoutContent<any>
-> = IFluidLayoutRowRenderer<
-    TCustomContent,
-    IDashboardViewLayoutRow<TCustomContent>,
-    IDashboardViewLayoutRowFacade<TCustomContent>,
-    IDashboardViewLayoutCommonRenderProps
->;
+> = IFluidLayoutRowRenderer<TCustomContent, IDashboardViewLayoutCommonRenderProps>;
 
 /**
  * @alpha
  */
 export type IDashboardViewLayoutRowHeaderRenderProps<
     TCustomContent extends IDashboardViewLayoutContent<any>
-> = IFluidLayoutRowHeaderRenderProps<
-    TCustomContent,
-    IDashboardViewLayoutRow<TCustomContent>,
-    IDashboardViewLayoutRowFacade<TCustomContent>
-> &
+> = IFluidLayoutRowHeaderRenderProps<TCustomContent> &
     IDashboardViewLayoutCommonRenderProps & {
         /**
          * Default row header renderer - can be used as a fallback for custom rowHeaderRenderer.
@@ -90,58 +62,35 @@ export type IDashboardViewLayoutRowHeaderRenderProps<
  */
 export type IDashboardViewLayoutRowHeaderRenderer<
     TCustomContent extends IDashboardViewLayoutContent<any>
-> = IFluidLayoutRowHeaderRenderer<
-    TCustomContent,
-    IDashboardViewLayoutRow<TCustomContent>,
-    IDashboardViewLayoutRowFacade<TCustomContent>,
-    IDashboardViewLayoutRowHeaderRenderProps<TCustomContent>
->;
+> = IFluidLayoutRowHeaderRenderer<TCustomContent, IDashboardViewLayoutRowHeaderRenderProps<TCustomContent>>;
 
 /**
  * @alpha
  */
 export type IDashboardViewLayoutColumnKeyGetter<
     TCustomContent extends IDashboardViewLayoutContent<any>
-> = IFluidLayoutColumnKeyGetter<
-    TCustomContent,
-    IDashboardViewLayoutColumn<TCustomContent>,
-    IDashboardViewLayoutColumnFacade<TCustomContent>
->;
+> = IFluidLayoutColumnKeyGetter<TCustomContent>;
 
 /**
  * @alpha
  */
 export type IDashboardViewLayoutColumnRenderProps<
     TCustomContent extends IDashboardViewLayoutContent<any>
-> = IFluidLayoutColumnRenderProps<
-    TCustomContent,
-    IDashboardViewLayoutColumn<TCustomContent>,
-    IDashboardViewLayoutColumnFacade<TCustomContent>
-> &
-    IDashboardViewLayoutCommonRenderProps;
+> = IFluidLayoutColumnRenderProps<TCustomContent> & IDashboardViewLayoutCommonRenderProps;
 
 /**
  * @alpha
  */
 export type IDashboardViewLayoutColumnRenderer<
     TCustomContent extends IDashboardViewLayoutContent<any>
-> = IFluidLayoutColumnRenderer<
-    TCustomContent,
-    IDashboardViewLayoutColumn<TCustomContent>,
-    IDashboardViewLayoutColumnFacade<TCustomContent>,
-    IDashboardViewLayoutColumnRenderProps<TCustomContent>
->;
+> = IFluidLayoutColumnRenderer<TCustomContent, IDashboardViewLayoutColumnRenderProps<TCustomContent>>;
 
 /**
  * @alpha
  */
 export type IDashboardViewLayoutContentRenderProps<
     TCustomContent extends IDashboardViewLayoutContent<any>
-> = IFluidLayoutContentRenderProps<
-    TCustomContent,
-    IDashboardViewLayoutColumn<TCustomContent>,
-    IDashboardViewLayoutColumnFacade<TCustomContent>
-> &
+> = IFluidLayoutContentRenderProps<TCustomContent> &
     IDashboardViewLayoutCommonRenderProps & {
         /**
          * React ref to content element.
@@ -190,12 +139,7 @@ export type IDashboardViewLayoutContentRenderProps<
  */
 export type IDashboardViewLayoutContentRenderer<
     TCustomContent extends IDashboardViewLayoutContent<any>
-> = IFluidLayoutContentRenderer<
-    TCustomContent,
-    IDashboardViewLayoutColumn<TCustomContent>,
-    IDashboardViewLayoutColumnFacade<TCustomContent>,
-    IDashboardViewLayoutContentRenderProps<TCustomContent>
->;
+> = IFluidLayoutContentRenderer<TCustomContent, IDashboardViewLayoutContentRenderProps<TCustomContent>>;
 
 /**
  * Dashboard layout definition.
@@ -204,12 +148,4 @@ export type IDashboardViewLayoutContentRenderer<
  */
 export type IDashboardViewLayoutRenderer<
     TCustomContent extends IDashboardViewLayoutContent<any>
-> = IFluidLayoutRenderer<
-    TCustomContent,
-    IDashboardViewLayoutRow<TCustomContent>,
-    IDashboardViewLayoutColumn<TCustomContent>,
-    IDashboardViewLayout<TCustomContent>,
-    IDashboardViewLayoutFacade<TCustomContent>,
-    IDashboardViewLayoutRowFacade<TCustomContent>,
-    IDashboardViewLayoutColumnFacade<TCustomContent>
->;
+> = IFluidLayoutRenderer<TCustomContent>;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayout.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayout.tsx
@@ -1,31 +1,14 @@
 // (C) 2007-2020 GoodData Corporation
 import React, { useMemo } from "react";
 import { Container, ScreenClassProvider, ScreenClassRender } from "react-grid-system";
-import {
-    ResponsiveScreenType,
-    FluidLayoutFacade,
-    IFluidLayoutRow,
-    IFluidLayoutColumn,
-    IFluidLayout,
-    IFluidLayoutFacade,
-    IFluidLayoutRowFacade,
-    IFluidLayoutColumnFacade,
-} from "@gooddata/sdk-backend-spi";
+import { ResponsiveScreenType, FluidLayoutFacade } from "@gooddata/sdk-backend-spi";
 import { FluidLayoutRow } from "./FluidLayoutRow";
 import { IFluidLayoutRenderer } from "./interfaces";
 
 /**
  * @alpha
  */
-export type IFluidLayoutProps<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TLayout extends IFluidLayout<TContent>,
-    TLayoutFacade extends IFluidLayoutFacade<TContent, TLayout>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
-> = IFluidLayoutRenderer<TContent, TRow, TColumn, TLayout, TLayoutFacade, TRowFacade, TColumnFacade>;
+export type IFluidLayoutProps<TContent> = IFluidLayoutRenderer<TContent>;
 
 /**
  * FluidLayout component takes fluid layout with any content,
@@ -35,17 +18,7 @@ export type IFluidLayoutProps<
  *
  * @alpha
  */
-export function FluidLayout<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TLayout extends IFluidLayout<TContent>,
-    TLayoutFacade extends IFluidLayoutFacade<TContent, TLayout>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
->(
-    props: IFluidLayoutRenderer<TContent, TRow, TColumn, TLayout, TLayoutFacade, TRowFacade, TColumnFacade>,
-): JSX.Element {
+export function FluidLayout<TContent>(props: IFluidLayoutRenderer<TContent>): JSX.Element {
     const {
         layout,
         layoutFacadeConstructor = FluidLayoutFacade.for,
@@ -69,7 +42,7 @@ export function FluidLayout<
                     render={(screen: ResponsiveScreenType) =>
                         screen ? (
                             <Container fluid={true} className={containerClassName}>
-                                {layoutFacade.rows().map((row: TRowFacade) => {
+                                {layoutFacade.rows().map((row) => {
                                     return (
                                         <FluidLayoutRow
                                             key={rowKeyGetter({

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutColumn.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutColumn.tsx
@@ -1,32 +1,20 @@
 // (C) 2007-2020 GoodData Corporation
 
 import { FluidLayoutColumnRenderer } from "./FluidLayoutColumnRenderer";
-import {
-    ResponsiveScreenType,
-    IFluidLayoutColumnFacade,
-    IFluidLayoutColumn,
-} from "@gooddata/sdk-backend-spi";
+import { ResponsiveScreenType, IFluidLayoutColumnFacade } from "@gooddata/sdk-backend-spi";
 import { IFluidLayoutColumnRenderer, IFluidLayoutContentRenderer } from "./interfaces";
 
 /**
  * @alpha
  */
-export interface IFluidLayoutColumnProps<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
-> {
-    column: TColumnFacade;
+export interface IFluidLayoutColumnProps<TContent> {
+    column: IFluidLayoutColumnFacade<TContent>;
     screen: ResponsiveScreenType;
-    columnRenderer?: IFluidLayoutColumnRenderer<TContent, TColumn, TColumnFacade>;
-    contentRenderer: IFluidLayoutContentRenderer<TContent, TColumn, TColumnFacade>;
+    columnRenderer?: IFluidLayoutColumnRenderer<TContent>;
+    contentRenderer: IFluidLayoutContentRenderer<TContent>;
 }
 
-export function FluidLayoutColumn<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
->(props: IFluidLayoutColumnProps<TContent, TColumn, TColumnFacade>): JSX.Element {
+export function FluidLayoutColumn<TContent>(props: IFluidLayoutColumnProps<TContent>): JSX.Element {
     const { column, columnRenderer = FluidLayoutColumnRenderer, contentRenderer, screen } = props;
     const renderProps = { column, screen };
 

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutColumnRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutColumnRenderer.tsx
@@ -2,13 +2,8 @@
 import React, { useMemo } from "react";
 import { IFluidLayoutColumnRenderer } from "./interfaces";
 import { Col } from "react-grid-system";
-import { IFluidLayoutColumn, IFluidLayoutColumnFacade } from "@gooddata/sdk-backend-spi";
 
-export const FluidLayoutColumnRenderer: IFluidLayoutColumnRenderer<
-    unknown,
-    IFluidLayoutColumn<unknown>,
-    IFluidLayoutColumnFacade<unknown, IFluidLayoutColumn<unknown>>
-> = (props) => {
+export const FluidLayoutColumnRenderer: IFluidLayoutColumnRenderer<unknown> = (props) => {
     const { column, children, className, minHeight } = props;
     const size = column.size();
     const style = useMemo(() => ({ minHeight }), [minHeight]);

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutRow.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutRow.tsx
@@ -1,12 +1,6 @@
 // (C) 2007-2020 GoodData Corporation
 import React from "react";
-import {
-    IFluidLayoutColumn,
-    IFluidLayoutColumnFacade,
-    IFluidLayoutRow,
-    IFluidLayoutRowFacade,
-    ResponsiveScreenType,
-} from "@gooddata/sdk-backend-spi";
+import { IFluidLayoutRowFacade, ResponsiveScreenType } from "@gooddata/sdk-backend-spi";
 import {
     IFluidLayoutColumnKeyGetter,
     IFluidLayoutColumnRenderer,
@@ -21,30 +15,18 @@ import { FluidLayoutRowRenderer } from "./FluidLayoutRowRenderer";
 /**
  * @alpha
  */
-export interface IFluidLayoutRowProps<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
-> {
-    row: TRowFacade;
-    rowKeyGetter?: IFluidLayoutRowKeyGetter<TContent, TRow, TRowFacade>;
-    rowRenderer?: IFluidLayoutRowRenderer<TContent, TRow, TRowFacade>;
-    rowHeaderRenderer?: IFluidLayoutRowHeaderRenderer<TContent, TRow, TRowFacade>;
-    columnKeyGetter?: IFluidLayoutColumnKeyGetter<TContent, TColumn, TColumnFacade>;
-    columnRenderer?: IFluidLayoutColumnRenderer<TContent, TColumn, TColumnFacade>;
-    contentRenderer?: IFluidLayoutContentRenderer<TContent, TColumn, TColumnFacade>;
+export interface IFluidLayoutRowProps<TContent> {
+    row: IFluidLayoutRowFacade<TContent>;
+    rowKeyGetter?: IFluidLayoutRowKeyGetter<TContent>;
+    rowRenderer?: IFluidLayoutRowRenderer<TContent>;
+    rowHeaderRenderer?: IFluidLayoutRowHeaderRenderer<TContent>;
+    columnKeyGetter?: IFluidLayoutColumnKeyGetter<TContent>;
+    columnRenderer?: IFluidLayoutColumnRenderer<TContent>;
+    contentRenderer?: IFluidLayoutContentRenderer<TContent>;
     screen: ResponsiveScreenType;
 }
 
-export function FluidLayoutRow<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
->(props: IFluidLayoutRowProps<TContent, TRow, TColumn, TRowFacade, TColumnFacade>): JSX.Element {
+export function FluidLayoutRow<TContent>(props: IFluidLayoutRowProps<TContent>): JSX.Element {
     const {
         row,
         rowRenderer = FluidLayoutRowRenderer,
@@ -56,7 +38,7 @@ export function FluidLayoutRow<
     } = props;
     const renderProps = { row, screen };
 
-    const columns = row.columns().map((columnFacade: TColumnFacade) => {
+    const columns = row.columns().map((columnFacade) => {
         return (
             <FluidLayoutColumn
                 key={columnKeyGetter({ column: columnFacade, screen })}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutRowRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutRowRenderer.tsx
@@ -2,13 +2,8 @@
 import React from "react";
 import { IFluidLayoutRowRenderer } from "./interfaces";
 import { Row } from "react-grid-system";
-import { IFluidLayoutRow, IFluidLayoutRowFacade } from "@gooddata/sdk-backend-spi";
 
-export const FluidLayoutRowRenderer: IFluidLayoutRowRenderer<
-    unknown,
-    IFluidLayoutRow<unknown>,
-    IFluidLayoutRowFacade<unknown, IFluidLayoutRow<unknown>>
-> = (props) => {
+export const FluidLayoutRowRenderer: IFluidLayoutRowRenderer<unknown> = (props) => {
     const { children, className } = props;
     return <Row className={className}>{children}</Row>;
 };

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/interfaces.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/interfaces.ts
@@ -1,10 +1,8 @@
 // (C) 2019-2021 GoodData Corporation
 import {
     IFluidLayout,
-    IFluidLayoutColumn,
     IFluidLayoutColumnFacade,
     IFluidLayoutFacade,
-    IFluidLayoutRow,
     IFluidLayoutRowFacade,
     ResponsiveScreenType,
 } from "@gooddata/sdk-backend-spi";
@@ -14,15 +12,11 @@ import {
  *
  * @alpha
  */
-export type IFluidLayoutRowKeyGetterProps<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>
-> = {
+export type IFluidLayoutRowKeyGetterProps<TContent> = {
     /**
      * Fluid layout row.
      */
-    row: TRowFacade;
+    row: IFluidLayoutRowFacade<TContent>;
 
     /**
      * Current screen type with respect to the set breakpoints.
@@ -39,26 +33,18 @@ export type IFluidLayoutRowKeyGetterProps<
  *
  * @alpha
  */
-export type IFluidLayoutRowKeyGetter<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>
-> = (props: IFluidLayoutRowKeyGetterProps<TContent, TRow, TRowFacade>) => string;
+export type IFluidLayoutRowKeyGetter<TContent> = (props: IFluidLayoutRowKeyGetterProps<TContent>) => string;
 
 /**
  * Default props provided to {@link IFluidLayoutRowRenderer}.
  *
  * @alpha
  */
-export type IFluidLayoutRowRenderProps<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>
-> = {
+export type IFluidLayoutRowRenderProps<TContent> = {
     /**
      * Fluid layout row.
      */
-    row: TRowFacade;
+    row: IFluidLayoutRowFacade<TContent>;
 
     /**
      * Current screen type with respect to the set breakpoints.
@@ -68,7 +54,7 @@ export type IFluidLayoutRowRenderProps<
     /**
      * Default renderer of the row - can be used as a fallback for custom rowRenderer.
      */
-    DefaultRowRenderer: IFluidLayoutRowRenderer<TContent, TRow, TRowFacade>;
+    DefaultRowRenderer: IFluidLayoutRowRenderer<TContent>;
 
     /**
      * Columns rendered by columnRenderer.
@@ -87,27 +73,20 @@ export type IFluidLayoutRowRenderProps<
  *
  * @alpha
  */
-export type IFluidLayoutRowRenderer<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>,
-    TCustomProps = object
-> = (renderProps: IFluidLayoutRowRenderProps<TContent, TRow, TRowFacade> & TCustomProps) => JSX.Element;
+export type IFluidLayoutRowRenderer<TContent, TCustomProps = object> = (
+    renderProps: IFluidLayoutRowRenderProps<TContent> & TCustomProps,
+) => JSX.Element;
 
 /**
  * Default props provided to {@link IFluidLayoutRowHeaderRenderer}.
  *
  * @alpha
  */
-export type IFluidLayoutRowHeaderRenderProps<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>
-> = {
+export type IFluidLayoutRowHeaderRenderProps<TContent> = {
     /**
      * Fluid layout row.
      */
-    row: TRowFacade;
+    row: IFluidLayoutRowFacade<TContent>;
 
     /**
      * Current screen type with respect to the set breakpoints.
@@ -121,27 +100,20 @@ export type IFluidLayoutRowHeaderRenderProps<
  *
  * @alpha
  */
-export type IFluidLayoutRowHeaderRenderer<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>,
-    TCustomProps = object
-> = (renderProps: IFluidLayoutRowHeaderRenderProps<TContent, TRow, TRowFacade> & TCustomProps) => JSX.Element;
+export type IFluidLayoutRowHeaderRenderer<TContent, TCustomProps = object> = (
+    renderProps: IFluidLayoutRowHeaderRenderProps<TContent> & TCustomProps,
+) => JSX.Element;
 
 /**
  * Default props provided to {@link IFluidLayoutColumnKeyGetter}
  *
  * @alpha
  */
-export type IFluidLayoutColumnKeyGetterProps<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
-> = {
+export type IFluidLayoutColumnKeyGetterProps<TContent> = {
     /**
      * Fluid layout column.
      */
-    column: TColumnFacade;
+    column: IFluidLayoutColumnFacade<TContent>;
 
     /**
      * Current screen type with respect to the set breakpoints.
@@ -158,26 +130,20 @@ export type IFluidLayoutColumnKeyGetterProps<
  *
  * @alpha
  */
-export type IFluidLayoutColumnKeyGetter<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
-> = (props: IFluidLayoutColumnKeyGetterProps<TContent, TColumn, TColumnFacade>) => string;
+export type IFluidLayoutColumnKeyGetter<TContent> = (
+    props: IFluidLayoutColumnKeyGetterProps<TContent>,
+) => string;
 
 /**
  * Default props provided to {@link IFluidLayoutColumnRenderer}
  *
  * @alpha
  */
-export type IFluidLayoutColumnRenderProps<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
-> = {
+export type IFluidLayoutColumnRenderProps<TContent, TCustomProps = object> = {
     /**
      * Fluid layout column.
      */
-    column: TColumnFacade;
+    column: IFluidLayoutColumnFacade<TContent>;
 
     /**
      * Current screen type with respect to the set breakpoints.
@@ -187,7 +153,7 @@ export type IFluidLayoutColumnRenderProps<
     /**
      * Default renderer of the column - can be used as a fallback for custom columnRenderer.
      */
-    DefaultColumnRenderer: IFluidLayoutColumnRenderer<TContent, TColumn, TColumnFacade>;
+    DefaultColumnRenderer: IFluidLayoutColumnRenderer<TContent, TCustomProps>;
 
     /**
      * Additional column css class name.
@@ -211,13 +177,8 @@ export type IFluidLayoutColumnRenderProps<
  *
  * @alpha
  */
-export type IFluidLayoutColumnRenderer<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>,
-    TCustomProps = object
-> = (
-    renderProps: IFluidLayoutColumnRenderProps<TContent, TColumn, TColumnFacade> & TCustomProps,
+export type IFluidLayoutColumnRenderer<TContent, TCustomProps = object> = (
+    renderProps: IFluidLayoutColumnRenderProps<TContent> & TCustomProps,
 ) => JSX.Element;
 
 /**
@@ -225,15 +186,11 @@ export type IFluidLayoutColumnRenderer<
  *
  * @alpha
  */
-export type IFluidLayoutContentRenderProps<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
-> = {
+export type IFluidLayoutContentRenderProps<TContent> = {
     /**
      * Fluid layout column.
      */
-    column: TColumnFacade;
+    column: IFluidLayoutColumnFacade<TContent>;
 
     /**
      * Current screen type with respect to the set breakpoints.
@@ -247,13 +204,8 @@ export type IFluidLayoutContentRenderProps<
  *
  * @alpha
  */
-export type IFluidLayoutContentRenderer<
-    TContent,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>,
-    TCustomProps = object
-> = (
-    renderProps: IFluidLayoutContentRenderProps<TContent, TColumn, TColumnFacade> & TCustomProps,
+export type IFluidLayoutContentRenderer<TContent, TCustomProps = object> = (
+    renderProps: IFluidLayoutContentRenderProps<TContent> & TCustomProps,
 ) => JSX.Element;
 
 /**
@@ -262,56 +214,48 @@ export type IFluidLayoutContentRenderer<
  *
  * @alpha
  */
-export type IFluidLayoutRenderer<
-    TContent,
-    TRow extends IFluidLayoutRow<TContent>,
-    TColumn extends IFluidLayoutColumn<TContent>,
-    TLayout extends IFluidLayout<TContent>,
-    TLayoutFacade extends IFluidLayoutFacade<TContent, TLayout>,
-    TRowFacade extends IFluidLayoutRowFacade<TContent, TRow>,
-    TColumnFacade extends IFluidLayoutColumnFacade<TContent, TColumn>
-> = {
+export type IFluidLayoutRenderer<TContent> = {
     /**
      * Fluid layout definition to render.
      */
-    layout: TLayout;
+    layout: IFluidLayout<TContent>;
 
     /**
      * Layout facade constructor (e.g. to support IDashboardViewLayoutFacade).
      */
-    layoutFacadeConstructor?: (layout: TLayout) => TLayoutFacade;
+    layoutFacadeConstructor?: (layout: IFluidLayout<TContent>) => IFluidLayoutFacade<TContent>;
 
     /**
      * Callback to determine a unique key of the row.
      * Check {@link IFluidLayoutRowKeyGetter} for more details.
      */
-    rowKeyGetter?: IFluidLayoutRowKeyGetter<TContent, TRow, TRowFacade>;
+    rowKeyGetter?: IFluidLayoutRowKeyGetter<TContent>;
 
     /**
      * Render props callback to customize row rendering.
      */
-    rowRenderer?: IFluidLayoutRowRenderer<TContent, TRow, TRowFacade>;
+    rowRenderer?: IFluidLayoutRowRenderer<TContent>;
 
     /**
      * Render props callback to customize row header rendering.
      */
-    rowHeaderRenderer?: IFluidLayoutRowHeaderRenderer<TContent, TRow, TRowFacade>;
+    rowHeaderRenderer?: IFluidLayoutRowHeaderRenderer<TContent>;
 
     /**
      * Callback to determine a unique key of the column.
      * Check {@link IFluidLayoutColumnKeyGetter} for more details.
      */
-    columnKeyGetter?: IFluidLayoutColumnKeyGetter<TContent, TColumn, TColumnFacade>;
+    columnKeyGetter?: IFluidLayoutColumnKeyGetter<TContent>;
 
     /**
      * Render props callback to customize column rendering.
      */
-    columnRenderer?: IFluidLayoutColumnRenderer<TContent, TColumn, TColumnFacade>;
+    columnRenderer?: IFluidLayoutColumnRenderer<TContent>;
 
     /**
      * Render props callback to specify how to render the content of the layout.
      */
-    contentRenderer: IFluidLayoutContentRenderer<TContent, TColumn, TColumnFacade>;
+    contentRenderer: IFluidLayoutContentRenderer<TContent>;
 
     /**
      * Additional css class name for the root element.


### PR DESCRIPTION
Makes TContent the only generic parameter as it is the only
truly generic thing. This makes the types a bit more lenient
but the gained simplicity is worth it imo.

JIRA: RAIL-2855

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
